### PR TITLE
updated files for safe cracker

### DIFF
--- a/external/vpx-safecracker/README.md
+++ b/external/vpx-safecracker/README.md
@@ -9,9 +9,9 @@ Download: [VpUniverse](https://vpuniverse.com/files/file/19850-safe-cracker-ball
 
 DirectB2S
 
-Authors: [ryguy417](https://vpuniverse.com/profile/31096-ryguy417/)
+Authors: [Wildman](https://vpuniverse.com/profile/5-wildman/)
 Version: 1.0.0
-Download: [VPUniverse](https://vpuniverse.com/files/file/13522-safe-cracker-bally-1996-b2s-with-full-dmd/)
+Download: [VPUniverse](https://vpuniverse.com/files/file/6999-safe-cracker-bally-1996/)
 
 ROMs: this table requires two roms: (1)sc_18n11 and (2)sc_18s11
 

--- a/external/vpx-safecracker/Safe Cracker (Bally 1996).ini
+++ b/external/vpx-safecracker/Safe Cracker (Bally 1996).ini
@@ -1,0 +1,12 @@
+[TableOverride]
+ViewCabMode = 0
+ViewCabScaleX = 0.786268
+ViewCabScaleY = 0.963607
+ViewCabScaleZ = 0.904995
+ViewCabRotation = 90.000000
+ViewCabPlayerX = -25.929987
+ViewCabPlayerY = -0.000000
+ViewCabPlayerZ = -340.000000
+ViewCabLookAt = 6.631500
+ViewCabFOV = 33.155807
+ViewCabLayback = 65.703011


### PR DESCRIPTION
updated readme to a different direct2bs and added .ini file that will disable vr and cabinet mode so the table loads correctly. Make sure to name the .vpx and the .direct2bs "Safe Cracker (Bally 1996)" exactly to match the .ini file

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
