### PR TITLE
randomized playfields

### DIFF
--- a/external/vpx-vampirella/README.md
+++ b/external/vpx-vampirella/README.md
@@ -36,5 +36,7 @@ Minimum VPX Standalone build: 10.8.0-1989-a764013
 - Download the table and directb2s listed above, extract (if necessary) and copy to external/vpx-vampirella
 - Make sure (.vpx), (.directb2s), (.vbs) and (.ini) files are all named the same
 - The ROM zip file gets copied to vpx-vampirella/pinmame/roms (Do not unzip)
-- This table has 4 different playfield images. See download page for how to choose
-- PICK C
+- This table has 4 different playfield images. They are randomized by default
+- Change Line 75 in the VBS to pick a specific playfield
+- Change x to 0, 1, 2, or 3. Table1.Image = playfieldImages(x) 
+- PICK C(2)

--- a/external/vpx-vampirella/Vampirella (Balutito 2024).vbs
+++ b/external/vpx-vampirella/Vampirella (Balutito 2024).vbs
@@ -60,6 +60,19 @@ Const SFlipperOff = "FlipperDown"
 Const SCoin = "Coin"
 Const MusicOn = true ' False if you don't want music
 
+ ' Define an array of playfield image names
+Dim playfieldImages(3)
+playfieldImages(0) = "PF VampirellaB"
+playfieldImages(1) = "PF VampirellaA"
+playfieldImages(2) = "PF VampirellaC"
+playfieldImages(3) = "PF VampirellaD"
+
+' Generate a random number between 0 and 3
+Dim randomIndex
+randomIndex = Int(Rnd * 4)
+
+' Set the playfield image using the randomly selected image
+Table1.Image = playfieldImages(randomIndex)
  
 Set GiCallback2 = GetRef("UpdateGI2")
  


### PR DESCRIPTION
Made a change to the VBS to randomize the playfield images.

Changed ReadMe to reflect the change and no longer needing to make an edit in VPX.

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
