### PR TITLE
Fix image links

### DIFF
--- a/external/vpx-jpmetallica/README.md
+++ b/external/vpx-jpmetallica/README.md
@@ -1,6 +1,6 @@
 # JP's Metallica Pro (Stern 2013)
 
-![Table Preview](https://www.vpforums.org/index.php?s=c4190c252e4b0afe20488a58dfe99e31&app=downloads&module=display&section=screenshot&record=119216&id=18612&full=1)
+![Table Preview](https://github.com/evilwraith/vpx-images/blob/main/vpx-jpmetallica.jpg)
 
 Authors: [jpsalas](https://www.vpforums.org/index.php?s=c4190c252e4b0afe20488a58dfe99e31&showuser=277)  
 Version: 1.0  

--- a/external/vpx-lordoftherings/README.md
+++ b/external/vpx-lordoftherings/README.md
@@ -1,6 +1,6 @@
 # JP's Lord of the Rings
 
-![Table Preview](https://www.vpforums.org/index.php?app=downloads&module=display&section=screenshot&record=114170&id=12898&full=1)
+![Table Preview](https://github.com/evilwraith/vpx-images/blob/main/vpx-lordoftherings.jpg)
 
 Authors: [jpsalas](https://www.vpforums.org/index.php?s=543a5ca562cc33a89debe8ace8834f1e&showuser=277)  
 Version: 4.3.0  

--- a/external/vpx-rad/README.md
+++ b/external/vpx-rad/README.md
@@ -1,5 +1,5 @@
 # Radical (Bally 1990)
-![Table Preview](https://www.vpforums.org/index.php?app=downloads&module=display&section=screenshot&record=104776&id=13694&full=1)
+![Table Preview](https://github.com/evilwraith/vpx-images/blob/main/vpx-rad.jpg)
 
 Author: [jpsalas](https://www.vpforums.org/index.php?showuser=277)  
 Version: Radical (Bally 1990) 4.0.0  

--- a/external/vpx-rambo/README.md
+++ b/external/vpx-rambo/README.md
@@ -1,6 +1,6 @@
 # Rambo First Blood Part II (TBA 2020)
 
-![Table Preview](https://www.vpforums.org/index.php?app=downloads&module=display&section=screenshot&record=75210&id=14885&full=1)
+![Table Preview](https://github.com/evilwraith/vpx-images/blob/main/vpx-rambo.png)
 
 Author(s): [ivantba](https://www.vpforums.org/index.php?showuser=123858)  
 VPX Version: Rambo First Blood Part II (TBA 2020).vpx  

--- a/external/vpx-safecracker/README.md
+++ b/external/vpx-safecracker/README.md
@@ -2,7 +2,7 @@
 
 Tested By: kaoticBPR
 
-![Table Preview](https://www.vpforums.org/index.php?app=downloads&module=display&section=screenshot&record=63196&id=13536&full=1)
+![Table Preview](https://github.com/evilwraith/vpx-images/blob/main/vpx-safecracker.jpg)
 
 Author: [fuzzel](https://www.vpforums.org/index.php?showuser=69907)  
 Version: 1.0  

--- a/external/vpx-seawitch/README.md
+++ b/external/vpx-seawitch/README.md
@@ -1,6 +1,6 @@
 # JP's Seawitch (Stern 1980)
 
-![Table Preview](https://www.vpforums.org/index.php?app=downloads&module=display&section=screenshot&record=114045&id=15265&full=1)
+![Table Preview](https://github.com/evilwraith/vpx-images/blob/main/vpx-seawitch.jpg)
 
 Authors: [jpsalas](https://www.vpforums.org/index.php?s=543a5ca562cc33a89debe8ace8834f1e&showuser=277)  
 Version: 4.3.0  

--- a/external/vpx-shootingtherapids/README.md
+++ b/external/vpx-shootingtherapids/README.md
@@ -1,7 +1,7 @@
 # Shooting the Rapids (Zaccaria 1979)
 Tested By: kaoticBPR
 
-![Table Preview](https://www.vpforums.org/index.php?app=downloads&module=display&section=screenshot&record=117539&id=18383&full=1)
+![Table Preview](https://github.com/evilwraith/vpx-images/blob/main/vpx-shootingtherapids.jpg)
 
 Authors: [JPSalas](https://www.vpforums.org/index.php?showuser=277)  
 Version: 1.0.0  

--- a/external/vpx-transformersg1/README.md
+++ b/external/vpx-transformersg1/README.md
@@ -1,6 +1,6 @@
 # Transformers G1 Generation One (TBA 2018) 1.7
 
-![Table Preview](https://www.vpforums.org/index.php?app=downloads&module=display&section=screenshot&record=65920&id=13658&full=1)
+![Table Preview](https://github.com/evilwraith/vpx-images/blob/main/vpx-transformersg1.png)
 
 Author(s): [ivantba](https://www.vpforums.org/index.php?showuser=123858)
 Download:  Transformers G1 (Generation One) Pinball (TBA 2018).zip

--- a/external/vpx-wowmonopoly/README.md
+++ b/external/vpx-wowmonopoly/README.md
@@ -1,6 +1,6 @@
 # WOW Monopoly, JPs (Original 2015)
 
-![Table Preview](https://www.vpforums.org/index.php?app=downloads&module=display&section=screenshot&record=104167&id=11612&full=1)
+![Table Preview](https://github.com/evilwraith/vpx-images/blob/main/vpx-wowmonopoly.jpg)
 
 Table
 


### PR DESCRIPTION
Fix image links from https://github.com/LegendsUnchained/vpx-standalone-alp4k/issues/778

Fish Tales done as I forgot to upload the image from my local repo.

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
