### PR TITLE
Killer instinct instructions fix

### DIFF
--- a/external/vpx-killerinstinct/README.md
+++ b/external/vpx-killerinstinct/README.md
@@ -23,6 +23,6 @@ Minimum VPX Standalone build: 10.8.0-1989-a764013
 ## Instructions
 
 - Copy the contents of this repo folder to your USB drive
-- Add your personalized launcher.elf and rename it to vpx-flintstones.elf
+- Add your personalized launcher.elf and rename it to vpx-killerinstinct.elf
 - Download the table and directb2s versions listed above and copy them into this folder
 - Once I’m done here, your planet is next.


### PR DESCRIPTION
Issue 1004
Int he instructions for the killer Instinct table in github it says to rename the elf to vpx-flintstones.elf. this is wrong and will not work

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
