### PR TITLE
fix: Update to DMD 2.5 for Godzilla

### DIFF
--- a/external/vpx-godzilla/table.yml
+++ b/external/vpx-godzilla/table.yml
@@ -1,6 +1,7 @@
 ---
 backglassVPSId: "7KE8QhZmDY"
-backglassChecksum: "a335771e268b230ea11ea7debc3e9f9e"
+backglassChecksum: "395C48FD5341A62DE0FD20FB5B992669"
+backglassNotes: "Download version 2.5"
 fps: 48
 romVPSId: "Q-UunvKK"
 romChecksum: "bb53c6e3c70060579851c70ffc22846f"


### PR DESCRIPTION
This updates the checksum for the table wizard to match the 2.5 version of the dmd file which was released on May 20th. Tested with latest at legends standalone files.

The 2.0 files are a bit hard to find on the vpuniverse site.

This addresses #1743 .
