### PR TITLE
Update table.ini to improve performance

### DIFF
--- a/external/vpx-thelaststarfighter/table.ini
+++ b/external/vpx-thelaststarfighter/table.ini
@@ -1,6 +1,11 @@
+[Standalone]
+BackBufferScale = 0.355729
+
 [Player]
 BallTrailStrength = 0.490196
 OverrideTableEmissionScale = 0
+MaxTexDimension = 3072
+FXAA = 1
 
 [TableOverride]
 ViewCabMode = 0


### PR DESCRIPTION
This updates the table.ini file to improve fps and latency performance of the table.

* BackBufferScale is set to 0.355729 to obtain nearly 59/60 fps
  * Note you could go with 0.416666 to get 50 fps but crisper graphics
* FXAA set to 1 - seems to improve latency and a few fps
* MaxTexDimension set to 3072, seems to gain a few fps here as well.

Combined these give about 58 to 60 fps, with some dips down to 54.