### PR TITLE
Update Back to the Future (Data East 1990) to v2.3 with vbs tweaks and sw29 kicker fix

### DIFF
--- a/external/vpx-bttf/README.md
+++ b/external/vpx-bttf/README.md
@@ -8,7 +8,7 @@
 
 | Playfield | Controls | Backglass | DMD | ROM Required | FPS | 
 |-----------|----------|-----------|-----|--------------|-----|
-| :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: | :white_check_mark: | 45 |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: |:white_check_mark: | :white_check_mark: | 40 |
 
 <br>
 

--- a/external/vpx-bttf/table.vbs
+++ b/external/vpx-bttf/table.vbs
@@ -1418,7 +1418,7 @@ End Sub
 Sub KickBallUp(Enabled)
 	Playsoundat SoundFX("Solenoid",DOFContactors),sw29
 	sw29.timerenabled = 1
- 	sw29.Kick 0,165,1.50
+ 	sw29.Kick 0,165,1.53
 	Controller.Switch(29) = 0
 	If WobblePlastic = 1 then
 		PlasticWobbling = 1

--- a/external/vpx-bttf/table.yml
+++ b/external/vpx-bttf/table.yml
@@ -1,8 +1,8 @@
 ---
 tableVPSId: "43ma3WQK"
 vpxVPSId: "nskyoXPp"
-vpxChecksum: "5128EDB94988AF936A968B2C94B11182"
-tableNotes: "'Download Back To The Future..._Bigus(MOD)2.2.vpx.zip'"
+vpxChecksum: "8b17b3f5c24e74d6f980e57cbd9a6055"
+tableNotes: "'Download Back To The Future..._Bigus(MOD)2.3.vpx.zip'"
 backglassVPSId: "nC5fd2Sk1b"
 backglassChecksum: "757ceb395bd69cf71b2e8f5dc0699053"
 backglassNotes: "Download 'Back to the Future 2-Screen B2S.rar'"


### PR DESCRIPTION

  Changes

- Updated `table.yml` to reference version 2.3 of the VPX table.
- Restored original tweaks to `table.vbs`, including the `sw29.Kick` fix.
- Adjusted `README.md` FPS value from 45 to 40 for accuracy.

  Checklist

- [x] README.md updated
- [ ] launcher.png (no change)
- [ ] launcher.xml (no change)
- [ ] pinmame/cfg, ini, nvram, roms present (no change)
- [x] Game-specific `table.vbs` modified with proper changes

  Notes

No VPX or ROM files were included. Only configuration and script changes relevant to the ALP4K version were submitted.
