### PR TITLE
Pinbot FPS Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,7 @@ Links to these products on Amazon are through affiliate links.
 | [O Gaucho (LTD do Brasil 1975)](external/vpx-ogaucho) | :white_check_mark: | :white_check_mark: | :x: | :x: | 60 |
 | [Pennant Fever (Williams 1984)](external/vpx-pennantfever) | :white_check_mark: | :x: | :white_check_mark: | :x: | 60 |
 | [Pharaoh - Dead Rise (Original 2019)](external/vpx-pharoahdr) | :white_check_mark: | :x: | :white_check_mark: | :x: | 48 |
-| [Pin-Bot (Williams 1986)](external/vpx-pinbot) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 45 |
+| [Pin-Bot (Williams 1986)](external/vpx-pinbot) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 52 |
 | [Pink Floyd (Original 2022)](external/vpx-pinkfloyd) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 42 |
 | [Pirates of the Caribbean (Stern 2006)](external/vpx-potc) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 55 |
 | [Playboy (Stern 2002)](external/vpx-playboy2002) | :white_check_mark: |:white_check_mark: | :white_check_mark: | :white_check_mark: | 60 |

--- a/external/vpx-pinbot/README.md
+++ b/external/vpx-pinbot/README.md
@@ -8,7 +8,7 @@
 
 | Playfield | Controls | Backglass | DMD | ROM Required | FPS | 
 |-----------|----------|-----------|-----|--------------|-----|
-| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | 45 |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | 52 |
 
 <br>
 

--- a/external/vpx-pinbot/table.ini
+++ b/external/vpx-pinbot/table.ini
@@ -4,6 +4,8 @@ OverrideTableEmissionScale = 1
 ScreenPlayerZ = 100.151230
 DynamicDayNight = 0
 EmissionScale = 0.200000
+FXAA = 4
+AAFactor = 0.80
 
 [TableOverride]
 ViewCabMode = 2

--- a/external/vpx-pinbot/table.yml
+++ b/external/vpx-pinbot/table.yml
@@ -8,7 +8,7 @@ backglassChecksum: "5D5DDAAAFBBD2DC529AFA880702060DA"
 backglassNotes: "Bundled with VPX"
 backglassAuthorsOverride:
   - "bord"
-fps: 40
+fps: 52
 romVPSId: "aSGrFJgL"
 romChecksum: "A0ACE6E5EEDC8D2EDCCB36E3FF26B1D3"
 romNotes: "Download - pb_l5.zip"


### PR DESCRIPTION
Adds AAFactor and FXAA 4 to the ini.  AAFactor is set to 0.80 which is about as low as it can go without starting to loose details on the playfield.  This gets it to about 52 fps, it will dip down to 49.
