### PR TITLE
Nightmare Before X-Mas fps update

### DIFF
--- a/README.md
+++ b/README.md
@@ -557,7 +557,7 @@ Links to these products on Amazon are through affiliate links.
 | [Night Moves (International Concepts 1989)](external/vpx-nightmoves) | :white_check_mark: | :x: | :white_check_mark: | :x: | 47 |
 | [Night of the Living Dead '68, Pinvention's (Original 2021)](external/vpx-nightofthelivingdeadpin) | :white_check_mark: | :x: | :x: | :x: | 38 |
 | [Night of the Living Dead '68 Grunge Mod (Original 2018)](external/vpx-nightofthelivingdeadgrunge) | :white_check_mark: | :x: | :x: | :x: | 45 |
-| [Nightmare Before Christmas (Original 2024)](external/vpx-nbc) | :white_check_mark: | :white_check_mark: | :x: | :x: | 30 |
+| [Nightmare Before Christmas (Original 2024)](external/vpx-nbc) | :white_check_mark: | :white_check_mark: | :x: | :x: | 39 |
 | [Night Rider (Bally 1977)](external/vpx-nightrider) | :white_check_mark: | :x: | :white_check_mark: | :x: | 60 |
 | [Nine Ball (Stern 1980)](external/vpx-nineball) | :white_check_mark: | :x: | :white_check_mark: | :x: | 45 |
 | [Nip-It (Bally 1973)](external/vpx-nipit) | :white_check_mark: | :white_check_mark: | :x: | :x: | 54 |

--- a/external/vpx-nbc/README.md
+++ b/external/vpx-nbc/README.md
@@ -12,7 +12,7 @@
 | **DMD** | N/A | N/A | N/A |
 | **ROM** | N/A | N/A | N/A |
 
-**Tested by:** [Bla1ze]
+**Tested by:** [Bla1ze],[kingargyle]
 
 ---
 
@@ -20,7 +20,7 @@
 **Minimum VPX Standalone build:** 10.8.0-1983-b84441e
 | Playfield | Controls | Backglass | DMD | ROM Required | FPS | 
 |-----------|----------|-----------|-----|--------------|-----|
-| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 30 |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 39 |
 
 ---
 

--- a/external/vpx-nbc/table.ini
+++ b/external/vpx-nbc/table.ini
@@ -8,8 +8,7 @@ ViewCabHOfs = 0.000000
 ViewCabVOfs = -9.282001
 ViewCabWindowTop = 373.230988
 ViewCabWindowBot = 110.671188
-EmissionScale = 1.000000
-
+ToneMapper = 0
 
 [Player]
 ScreenPlayerY = 17.309704
@@ -17,5 +16,15 @@ ScreenPlayerZ = 95.334305
 ScreenWidth = 0.000000
 ScreenHeight = 0.000000
 ScreenInclination = 0.000000
-MaxTexDimension = 3072
 FXAA = 1
+AAFactor = 0.70
+BallTrailStrength = 0.200000
+OverrideTableEmissionScale = 1
+DynamicDayNight = 0
+EmissionScale = 0.60
+
+[Standalone]
+BackBufferScale = 0.333333
+
+[TableOption]
+VR Room = 0.000000

--- a/external/vpx-nbc/table.vbs
+++ b/external/vpx-nbc/table.vbs
@@ -687,7 +687,7 @@ End Sub
 
 
 
-GameTimer.interval = 13
+GameTimer.interval = 20
 Sub GameTimer_Timer
 	Dim tmp
 	RollingUpdate


### PR DESCRIPTION
Bumps the FPS to about 39 max.  This table has some pretty ugly vbs which is causing some of the performance issues.  It is also brittle
to change.   This update does the following:

1. changes vbs gametimer from 13 to 20.
2. Sets back buffer scale to 0.333333
3. AAFactor to 0.70
4. FXAA = 1
5. Updates the Emission to about 0.60
6. Turns off the VR Room
7. ToneMapper to 0.

Not much more I think can be squeazed from this table unfortunately.

