### PR TITLE
Godzilla (Sega) FPS update

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ Links to these products on Amazon are through affiliate links.
 | [Ghostbusters Slimer, JP's (Original 2017)](external/vpx-slimerjp) | :white_check_mark: | :white_check_mark: | :x: | :x: | 55 |
 | [Gilligan's Island (Bally 1991)](external/vpx-gilligansisland) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 50 |
 | [Gladiators (Gottlieb 1993)](external/vpx-gladiators) | :white_check_mark: |:white_check_mark: | :white_check_mark: | :x: | 50 |
-| [Godzilla (Sega 1998)](external/vpx-godzilla) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 48 |
+| [Godzilla (Sega 1998)](external/vpx-godzilla) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 58 |
 | [Gold Wings (Gottlieb 1986)](external/vpx-goldwings) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 60 |
 | [Goldeneye (Sega 1996)](external/vpx-goldeneye) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 48 |
 | [Gorgar (Williams 1979)](external/vpx-gorgar) | :white_check_mark: |:white_check_mark: | :white_check_mark: | :x: | 60 |

--- a/external/vpx-godzilla/README.md
+++ b/external/vpx-godzilla/README.md
@@ -8,13 +8,14 @@
 
 | Playfield | Controls | Backglass | DMD | ROM Required | FPS | 
 |-----------|----------|-----------|-----|--------------|-----|
-| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | 48 |
+| :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | :white_check_mark: | 58 |
 
 <br>
 
 **VPXS 4KP Testers:**
   - KaoticBPR
   - OminousOsie 🌸
+  - kingargyle
 
 <br>
 

--- a/external/vpx-godzilla/table.ini
+++ b/external/vpx-godzilla/table.ini
@@ -2,7 +2,8 @@
 BackBufferScale = 0.416666
 
 [Player]
-FXAA = 1
+FXAA = 4
+AAFactor = 0.98
 MaxTexDimension = 4096
 OverrideTableEmissionScale = 1
 ScreenPlayerY = 20.049940

--- a/external/vpx-godzilla/table.yml
+++ b/external/vpx-godzilla/table.yml
@@ -2,7 +2,7 @@
 backglassVPSId: "7KE8QhZmDY"
 backglassChecksum: "395C48FD5341A62DE0FD20FB5B992669"
 backglassNotes: "Download version 2.5"
-fps: 48
+fps: 58
 romVPSId: "Q-UunvKK"
 romChecksum: "bb53c6e3c70060579851c70ffc22846f"
 tableVPSId: "fGz4ZrUb"
@@ -10,6 +10,7 @@ tagline: "Size DOES matter!"
 testers:
   - "KaoticBPR"
   - "OminousOsie"
+  - "kingargyle"
 vpxVPSId: "agV0wfgx"
 vpxChecksum: "1960efa0b0eb32ffc9cc3fe25a36666f"
 applyFixes:


### PR DESCRIPTION
Adds the following settings:
* AAFactor = 0.98
* FXAA = 4

Table plays about an average 58 fps now, no table fidelity loss.