### PR TITLE
Big Trouble Little China POV and Resolution Update

### DIFF
--- a/external/vpx-big_trouble/README.md
+++ b/external/vpx-big_trouble/README.md
@@ -15,6 +15,7 @@
 **VPXS 4KP Testers:**
   - T3chZombie
   - OminousOsie 🌸
+  - kingargyle
 
 <br>
 

--- a/external/vpx-big_trouble/table.ini
+++ b/external/vpx-big_trouble/table.ini
@@ -1,20 +1,26 @@
+; POV based on LoadedWeapon's POV https://vpuniverse.com/files/file/22213-big-trouble-in-little-china-cabinet-pov/
 [Standalone]
 WindowRenderMode = 0
+BackBufferScale = 0.666666
 
 [Player]
 BallTrailStrength = 0.392157
 OverrideTableEmissionScale = 0
+ScreenPlayerY = 16.303198
+ScreenPlayerZ = 103.336784
+ScreenWidth = 0.000000
+ScreenHeight = 0.000000
+ScreenInclination = 0.000000
+AAFactor = 0.90
 FXAA = 1
 
 [TableOverride]
-ViewCabMode = 0
-ViewCabScaleX = 0.934824
-ViewCabScaleY = 1.285660
-ViewCabScaleZ = 1.000050
-ViewCabRotation = 90.000000
-ViewCabPlayerX = 6.650113
-ViewCabPlayerY = 0.525000
-ViewCabPlayerZ = -370.550049
-ViewCabLookAt = 6.999999
-ViewCabFOV = 27.000000
-ViewCabLayback = 76.000000
+ViewCabMode = 2
+ViewCabScaleX = 1.219269
+ViewCabScaleY = 1.021921
+ViewCabScaleZ = 1.000000
+ViewCabRotation = 180.000000
+ViewCabHOfs = 0.000000
+ViewCabVOfs = -11.148900
+ViewCabWindowTop = 361.388947
+ViewCabWindowBot = 134.747238

--- a/external/vpx-big_trouble/table.ini
+++ b/external/vpx-big_trouble/table.ini
@@ -1,6 +1,5 @@
 ; POV based on LoadedWeapon's POV https://vpuniverse.com/files/file/22213-big-trouble-in-little-china-cabinet-pov/
 [Standalone]
-WindowRenderMode = 0
 BackBufferScale = 0.666666
 
 [Player]

--- a/external/vpx-big_trouble/table.yml
+++ b/external/vpx-big_trouble/table.yml
@@ -7,6 +7,7 @@ tagline: "Remember, \"It's All In The Reflexes!\" ---Jack Burton"
 testers:
   - "T3chZombie"
   - "OminousOsie"
+  - "kingargyle"
 vpxVPSId: "xxxNFKri-k"
 vpxChecksum: "2f71277f67c922f692c57106a46bfd2e"
 tableNotes: "Download 'Big Trouble 1.5 DOF no puppack user.vpx'"


### PR DESCRIPTION
This updates the POV to use the Window mode (ViewCabMode 2).  It uses LoadWeapon's POV for cabinet mode.  Rotation applied to the playfield to get the field oriented correctly.

In addition, updated BackBufferScale to one level higher, and added AAFactor to help with fps at the higher resolution.

Overall the new POV applies a more realistic view and helps with that crazy first plunger ball shot to make it a bit more realistic speed wise.

Included link to LoadWeapon's POV in the ini file.

POV Source: https://vpuniverse.com/files/file/22213-big-trouble-in-little-china-cabinet-pov/