### PR TITLE
Resolution Update for JP Attack from Mars

### DIFF
--- a/external/vpx-jpattackfrommars/table.ini
+++ b/external/vpx-jpattackfrommars/table.ini
@@ -1,5 +1,6 @@
 [Standalone]
 WindowRenderMode = 0
+BackBufferScale = 0.666666
 
 [Player]
 BallTrailStrength = 0.000000
@@ -12,6 +13,8 @@ EmissionScale = 0.301825
 ScreenWidth = 0.000000
 ScreenHeight = 0.000000
 ScreenInclination = 0.000000
+AAFactor = 0.95
+FXAA = 4
 
 [TableOverride]
 ViewCabMode = 2


### PR DESCRIPTION
Updates the resolution to 1440p and keeps in the 55 - 60fps range.

AAFactor = 0.95
FXAA = 4 (could left at default 1 but doesn't suffer from 4)
