### PR TITLE
Medieval Madness wiz serum update

### DIFF
--- a/external/vpx-mm/table.ini
+++ b/external/vpx-mm/table.ini
@@ -9,6 +9,7 @@ OverrideTableEmissionScale = 1
 DynamicDayNight = 0
 EmissionScale = 0.350000
 ScreenPlayerY = 3.549998
+AAFactor = 0.95
 
 [TableOverride]
 ViewCabMode = 2

--- a/external/vpx-mm/table.yml
+++ b/external/vpx-mm/table.yml
@@ -8,7 +8,7 @@ romNotes: "Download mm_109c.zip"
 coloredROMVPSId: "i8vJolcLwI"
 coloredROMChecksum: "EDA821AA80192B186C66045B55B4F960"
 coloredROMNotes: "Download Version 1.1.0"
-fps: 40
+fps: 48
 tableVPSId: "-5yMpqSy"
 tableNotes: "Download Version (Real Final)"
 tagline: "Is that a sword in your pocket?"

--- a/external/vpx-mm/table.yml
+++ b/external/vpx-mm/table.yml
@@ -1,12 +1,16 @@
 ---
 backglassVPSId: "kaoLtHsb"
 backglassChecksum: "CD9C60B159BFFC4696EBDCBBC33CD704"
+backglassNotes: "Download Version 3.0"
 romVPSId: "VMV5-Loj"
 romChecksum: "2215E20B0C370B64D3DF34AE17A8BF45"
+romNotes: "Download mm_109c.zip"
 coloredROMVPSId: "i8vJolcLwI"
-coloredROMChecksum: "427cf06570993c2ea1d067f484768605"
+coloredROMChecksum: "EDA821AA80192B186C66045B55B4F960"
+coloredROMNotes: "Download Version 1.1.0"
 fps: 40
 tableVPSId: "-5yMpqSy"
+tableNotes: "Download Version (Real Final)"
 tagline: "Is that a sword in your pocket?"
 testers:
   - "mcap"


### PR DESCRIPTION
Updated Serum to version 1.1 released in October 2025.
Updated yml to add notes.
Added AAFactor = 0.95 for a few extra frames.
