### PR TITLE
Add altsound support to table.yml schema and vpsdb resolver

### DIFF
--- a/.github/workflows/scripts/validate-table-yaml.py
+++ b/.github/workflows/scripts/validate-table-yaml.py
@@ -85,6 +85,29 @@ def check_bundled(meta):
                     print(f"ERROR: romNotes is not a string in table: {table}")
                     sys.exit(1)
 
+        if table_meta.get("altSoundBundled"):
+            if (
+                "altSoundNotes" not in table_meta
+                or table_meta["altSoundNotes"] is None
+            ):
+                print(
+                    f"ERROR: altSoundBundled is True but altSoundNotes is not found in table: {table}"
+                )
+                sys.exit(1)
+
+            if (
+                "altSoundChecksum" not in table_meta
+                or table_meta["altSoundChecksum"] is None
+            ):
+                print(
+                    f"ERROR: altSoundBundled is True but altSoundChecksum is not found in table: {table}"
+                )
+                sys.exit(1)
+
+            if not isinstance(table_meta["altSoundNotes"], str):
+                print(f"ERROR: altSoundNotes is not a string in table: {table}")
+                sys.exit(1)
+
 def check_checksums(meta):
     """Checks that required checksums are present.
 
@@ -124,6 +147,16 @@ def check_checksums(meta):
             or table_meta["coloredROMChecksum"] is None
         ):
             print(f"ERROR: coloredROMChecksum field not found in table: {table}")
+            sys.exit(1)
+
+        if (
+            "altSoundFileUrl" in table_meta
+            and table_meta["altSoundFileUrl"] is not None
+        ) and (
+            "altSoundChecksum" not in table_meta
+            or table_meta["altSoundChecksum"] is None
+        ):
+            print(f"ERROR: altSoundChecksum field not found in table: {table}")
             sys.exit(1)
 
         if ("pupFileUrl" in table_meta and table_meta["pupFileUrl"] is not None) and (
@@ -345,6 +378,24 @@ def check_overrides(meta):
         if "romVersionOverride" not in meta or meta["romVersionOverride"] is None:
             print(
                 f"ERROR: romUrlOverride defined and romVersionOverride field not found"
+            )
+            sys.exit(1)
+
+    if "altSoundUrlOverride" in meta and meta["altSoundUrlOverride"] is not None:
+        if not isinstance(meta["altSoundUrlOverride"], str):
+            print(f"ERROR: altSoundUrlOverride is not a string")
+            sys.exit(1)
+
+        if "altSoundVPSId" in meta and meta["altSoundVPSId"] is not None:
+            print(f"ERROR: altSoundVPSId is not allowed with altSoundUrlOverride")
+            sys.exit(1)
+
+        if (
+            "altSoundVersionOverride" not in meta
+            or meta["altSoundVersionOverride"] is None
+        ):
+            print(
+                f"ERROR: altSoundUrlOverride defined and altSoundVersionOverride field not found"
             )
             sys.exit(1)
 

--- a/.github/workflows/scripts/vpsdb.py
+++ b/.github/workflows/scripts/vpsdb.py
@@ -162,6 +162,7 @@ def get_table_meta(files, warn_on_error=True):
             data = yaml.safe_load(table_data)
 
         altSoundVPSId = data.get("altSoundVPSId")
+        altSoundUrlOverride = data.get("altSoundUrlOverride")
         backglassVPSId = data.get("backglassVPSId")
         coloredROMVPSId = data.get("coloredROMVPSId")
         diffVPSId = data.get("diffVPSId")
@@ -185,7 +186,14 @@ def get_table_meta(files, warn_on_error=True):
         pupChecksum = normalize_checksums(data.get("pupChecksum"))
 
         table_meta = {
+            "altSoundAuthors": data.get("altSoundAuthorsOverride"),
+            "altSoundBundled": data.get("altSoundBundled"),
             "altSoundChecksum": altSoundChecksum,
+            "altSoundFileUrl": altSoundUrlOverride,
+            "altSoundNotes": data.get("altSoundNotes"),
+            "altSoundVersion": data.get("altSoundVersionOverride"),
+            "altSoundArchiveFormat": data.get("altSoundArchiveFormat"),
+            "altSoundArchiveRoot": data.get("altSoundArchiveRoot"),
             "applyFixes": data.get("applyFixes"),
             "backglassAuthors": data.get("backglassAuthorsOverride"),
             "backglassBundled": data.get("backglassBundled"),
@@ -355,11 +363,14 @@ def get_table_meta(files, warn_on_error=True):
             altSound = vpsdb.get_altsound_by_id(altSoundVPSId)
             if altSound:
                 print(f"Parsing alt sound {altSoundVPSId} for {folder_name}")
-                table_meta["altSoundAuthors"] = altSound.get("authors", [])
+
+                if not table_meta["altSoundAuthors"]:
+                    table_meta["altSoundAuthors"] = altSound.get("authors", [])
                 table_meta["altSoundComment"] = altSound.get("comment", "")
-                table_meta["altSoundFileUrl"] = altSound.get("urls", [])[0].get(
-                    "url", ""
-                )
+                if not table_meta["altSoundFileUrl"]:
+                    table_meta["altSoundFileUrl"] = altSound.get("urls", [])[0].get(
+                        "url", ""
+                    )
                 if not table_meta["altSoundVersion"]:
                     table_meta["altSoundVersion"] = altSound.get("version", "")
             else:

--- a/doc/advanced/wizardtable.adoc
+++ b/doc/advanced/wizardtable.adoc
@@ -24,6 +24,15 @@ Here is an example of every field possible: (as of 27 May 2025)
 
 ....
 additionalRoms:              | [Array of Objects]
+altSoundArchiveFormat:       | [String]
+altSoundArchiveRoot:         | [String]
+altSoundAuthorsOverride:     | [Array]
+altSoundBundled:             | [Bool]
+altSoundChecksum:            | [String]
+altSoundNotes:               | [String]
+altSoundUrlOverride:         | [String]
+altSoundVersionOverride:     | [String]
+altSoundVPSId:               | [String]
 applyFixes:                  | [Array]
 backglassAuthorsOverride:    | [Array]
 backglassBundled:            | [Bool]
@@ -65,6 +74,58 @@ vpxVPSId:                    | [String]
 
 Below is each yml field explained, with an example, and any `gotchas'
 that you need to know to use successfully!
+
+....
+########################
+altSound (altSoundVPSId / altSoundUrlOverride / ...)
+########################
+
+Type:
+------------
+Group of fields (see below)
+
+Description:
+------------
+An altsound pack replaces a table's ROM audio with an alternative/orchestral
+sound package. It is distributed as an archive (zip/rar/7z) and is extracted on
+the device into the ROM's altsound folder (pinmame/altsound/<romname>), so a
+table that offers altsound MUST also install its ROM.
+
+Resolve the pack from VPS with altSoundVPSId, OR link it directly with
+altSoundUrlOverride (+ altSoundVersionOverride). altSoundChecksum is required
+whenever altsound is offered or bundled. Fields:
+
+- altSoundVPSId: [String] VPS ID of the altsound file; resolves authors / url /
+  version. Mutually exclusive with altSoundUrlOverride.
+- altSoundUrlOverride: [String] direct download URL, used INSTEAD of
+  altSoundVPSId when the pack isn't on VPS.
+- altSoundVersionOverride: [String] REQUIRED when altSoundUrlOverride is set.
+- altSoundAuthorsOverride: [Array] overrides the VPS-resolved authors.
+- altSoundChecksum: [String|List] MD5(s) of the archive. REQUIRED when offered
+  or bundled. One hash -> a string; two or more -> a YAML list.
+- altSoundNotes: [String] Markdown notes shown on the wizard row. REQUIRED when
+  altSoundBundled is true.
+- altSoundBundled: [Bool] the pack ships inside the table download itself.
+- altSoundArchiveFormat: [String] zip | rar | 7z. Default: zip. Only sets the
+  wizard's file picker filter; extraction auto-detects the real format.
+- altSoundArchiveRoot: [String] path within the archive to the altsound root,
+  when the pack is nested inside a subfolder.
+
+Example:
+------------
+altSoundVPSId: "FfXJriyfGA"
+altSoundChecksum: "00000000000000000000000000000000"
+altSoundNotes: "Download version 1.0.0"
+
+Gotchas:
+------------
+- Altsound needs a ROM. If the table has no rom (romVPSId/romUrlOverride) the
+  install has no romname to extract into and will fail.
+- Like coloredROM, VPS altsound entries have no checksum, so altSoundChecksum
+  always comes from this file.
+- The VPS url is usually a VPUniverse page link, not a direct download — that's
+  expected; the wizard opens it so the user can grab the file.
+....
 
 ....
 ########################

--- a/external/vpx-cactuscanyon/table.yml
+++ b/external/vpx-cactuscanyon/table.yml
@@ -12,5 +12,6 @@ testers:
   - "CoffeeAtJoes"
 vpxVPSId: "2XtND6uteu"
 vpxChecksum: "67812720881aa43441ce7a6c6595b60a"
-applyFixes:
-  - "bass"
+altSoundVPSId: "uh9-lEk7"
+altSoundChecksum: "c4d6e709ef159268fd21692b86ec3f52"
+altSoundArchiveRoot: "cc_13"

--- a/table.yml.example
+++ b/table.yml.example
@@ -134,8 +134,20 @@ testers:
 
 
 # --- Alt sound (optional) ---------------------------------------------------
+# An altsound pack is an archive (zip/rar/7z) extracted into the ROM's altsound
+# folder, so a table offering altsound must also install its ROM. Use EITHER
+# altSoundVPSId (on VPS) OR altSoundUrlOverride (+ altSoundVersionOverride).
+# altSoundChecksum is REQUIRED when altsound is offered or bundled.
 # altSoundVPSId: "xxxxxxxx"                       # [String] resolves authors / url / version
+# altSoundUrlOverride: "https://..."              # [String] use INSTEAD of altSoundVPSId (not both)
+# altSoundVersionOverride: "name"                 # [String] REQUIRED with altSoundUrlOverride
+# altSoundAuthorsOverride:                        # [List] override resolved authors
+#   - "author"
 # altSoundChecksum: "00000000000000000000000000000000"   # [String|List]
+# altSoundNotes: "Markdown notes."                # [String] REQUIRED when bundled
+# altSoundBundled: false                          # [Boolean] altsound ships inside the table download
+# altSoundArchiveFormat: "zip"                    # [String] zip | rar | 7z  (default: zip)
+# altSoundArchiveRoot: "subfolder"                # [String] path within the archive to the altsound root (if nested)
 
 
 # --- Tutorial (optional) ----------------------------------------------------


### PR DESCRIPTION
Adds the full altSound field group (vpsid, urlOverride/versionOverride, authorsOverride, checksum, notes, bundled, archiveFormat, archiveRoot) to table.yml, resolves it in vpsdb.py (also fixes a latent KeyError where altSoundVersion was read but never initialized), and validates it in validate-table-yaml.py. Enables altsound on vpx-cactuscanyon.

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
