### PR TITLE
Update vpx-got README.md to include adding gameofthronesFlexDMD folder

### DIFF
--- a/problem-tables/vpx-got/README.md
+++ b/problem-tables/vpx-got/README.md
@@ -25,5 +25,5 @@ Minimum VPX Standalone build: 10.8.0-1989-a764013
 - Copy the contents of this repo folder to your USB drive
 - Add your personalized launcher.elf and rename it to vpx-got.elf
 - Download the table and directb2s versions listed above, extract (if necessary) and copy them to `external/vpx-got`
-- Extract the 'gameofthrones.FlexDMD' folder from table zip and copy the entire folder to `external/vpx-got`
+- Extract 'gameofthrones.FlexDMD' folder from table zip and copy the entire folder to `external/vpx-got`
 - Make sure `(.vpx)`, `(.directb2s)`, `(.ini)` and `(.vbs)` files are all named the same

--- a/problem-tables/vpx-got/README.md
+++ b/problem-tables/vpx-got/README.md
@@ -25,4 +25,5 @@ Minimum VPX Standalone build: 10.8.0-1989-a764013
 - Copy the contents of this repo folder to your USB drive
 - Add your personalized launcher.elf and rename it to vpx-got.elf
 - Download the table and directb2s versions listed above, extract (if necessary) and copy them to `external/vpx-got`
+- Extract the 'gameofthrones.FlexDMD' folder from table zip and copy the entire folder to `external/vpx-got`
 - Make sure `(.vpx)`, `(.directb2s)`, `(.ini)` and `(.vbs)` files are all named the same


### PR DESCRIPTION
Instructions in README were missing a step to extract the FlexDMD folder within the VPW 1.2 table zip and uploading it directly to external/vpx-got table folder

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
