### PR TITLE
Update smb .yml rom instructions 

### DIFF
--- a/external/vpx-supermario/table.yml
+++ b/external/vpx-supermario/table.yml
@@ -7,7 +7,7 @@ coloredROMNotes: "Download - smb3.cROMc"
 coloredROMVPSId: "b8LTuHqo7N"
 fps: 60
 romChecksum: "5BBBF451CDF5353B7B5D69BA17DA8825"
-romNotes: "Download - smb3.zip"
+romNotes: "Download -  smb3.zip"
 romUrlOverride: "https://pinballnirvana.com/forums/resources/smb3.2317/"
 romVersionOverride: "smb3"
 tagline: "It's-a me, Mario!"

--- a/external/vpx-supermario/table.yml
+++ b/external/vpx-supermario/table.yml
@@ -7,7 +7,11 @@ coloredROMNotes: "Download - smb3.cROMc"
 coloredROMVPSId: "b8LTuHqo7N"
 fps: 60
 romChecksum: "5BBBF451CDF5353B7B5D69BA17DA8825"
+<<<<<<< Updated upstream
 romNotes: "'smb3.zip' | Extract 'smb3.zip' from - 'smb3_rom for VPinMAME 3.5 (rev 9-20-2022) Zipped rom inside.zip'"
+=======
+romNotes: "Download - smb3.zip"
+>>>>>>> Stashed changes
 romUrlOverride: "https://pinballnirvana.com/forums/resources/smb3.2317/"
 romVersionOverride: "smb3"
 tagline: "It's-a me, Mario!"

--- a/external/vpx-supermario/table.yml
+++ b/external/vpx-supermario/table.yml
@@ -7,8 +7,8 @@ coloredROMNotes: "Download - smb3.cROMc"
 coloredROMVPSId: "b8LTuHqo7N"
 fps: 60
 romChecksum: "5BBBF451CDF5353B7B5D69BA17DA8825"
-romNotes: "'smb3.zip' | Extract 'smb3.zip' from - 'smb3_rom for VPinMAME 3.5 (rev 9-20-2022) Zipped rom inside.zip'"
-romUrlOverride: "https://pinballnirvana.com/forums/resources/smb3.2317/"
+romNotes: "Download - smb3.zip"
+romUrlOverride: "https://pinballnirvana.com/forums/resources/smb3.2317/version/7771/download?file=34769"
 romVersionOverride: "smb3"
 tagline: "It's-a me, Mario!"
 testers:

--- a/external/vpx-supermario/table.yml
+++ b/external/vpx-supermario/table.yml
@@ -7,11 +7,7 @@ coloredROMNotes: "Download - smb3.cROMc"
 coloredROMVPSId: "b8LTuHqo7N"
 fps: 60
 romChecksum: "5BBBF451CDF5353B7B5D69BA17DA8825"
-<<<<<<< Updated upstream
-romNotes: "'smb3.zip' | Extract 'smb3.zip' from - 'smb3_rom for VPinMAME 3.5 (rev 9-20-2022) Zipped rom inside.zip'"
-=======
 romNotes: "Download - smb3.zip"
->>>>>>> Stashed changes
 romUrlOverride: "https://pinballnirvana.com/forums/resources/smb3.2317/"
 romVersionOverride: "smb3"
 tagline: "It's-a me, Mario!"


### PR DESCRIPTION
Changes rom instructions to point at smb3.zip instead of the .zip within a .zip.  That is the only change.  Excuse my commit trail mess below.  Everything got stuck in a loop so I had to put the change through a bunch of times.  



<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
