### PR TITLE
Secret service Disable PinMAMEwindow

### DIFF
--- a/external/vpx-secretservice/table.ini
+++ b/external/vpx-secretservice/table.ini
@@ -17,3 +17,6 @@ ViewCabHOfs = 9.617002
 ViewCabVOfs = 0.000000
 ViewCabWindowTop = 221.845245
 ViewCabWindowBot = 126.807220
+
+[Standalone]
+PinMAMEWindow = 0


### PR DESCRIPTION
It was covering up the dmd.png art.  Not needed.  Scoring is on backglass.  Folks are seeing it in the tourney this week 

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
