### PR TITLE
Fixed x-files han table name

### DIFF
--- a/external/vpx-xfileshanibal/table.yml
+++ b/external/vpx-xfileshanibal/table.yml
@@ -2,7 +2,7 @@
 coloredROMChecksum: "10F5840B4F387F130FD932BCD03D505B"
 coloredROMNotes: "Download 'xfiles.cROMc'"
 coloredROMVPSId: "7LUZid35oQ"
-tableNameOverride: "X Files, The Hannibal Mod (Sega 1997)"
+tableNameOverride: "X Files, The Hannibal Mod"
 tableVPSId: "ImqfuWt4"
 vpxVPSId: "sj6R53Tf"
 vpxChecksum: "98024cbcd05756e86c2b0da3be8d052b"


### PR DESCRIPTION
Current: 
<img width="965" height="227" alt="image" src="https://github.com/user-attachments/assets/b17f87c9-38ad-49c2-9a74-0fe00353e45f" />


Fixed: 

<img width="960" height="199" alt="image" src="https://github.com/user-attachments/assets/d21b7e89-3532-43d9-a50e-2c74ca1394bd" />


<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
