### PR TITLE
Move Dark Chaos from manual to wiz readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,7 @@ Links to these products on Amazon are through affiliate links.
 | [Creature from the Black Lagoon (Bally 1992)](external/vpx-cftbl) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 60 |
 | [Crystal-Ball (Talleres del Llobregat 1970)](external/vpx-crystalball) | :white_check_mark: | :x: | :x: | :x: | 60 |
 | [CSI (Stern 2008)](external/vpx-csiled) | :x: | :white_check_mark: | :white_check_mark: | :x: | 60 |
+| [Dark Chaos, (Original 2025)](external/vpx-darkchaos) | :white_check_mark: | :x: | :x: | :x: | 60 |
 | [Dark Crystal Pinball, The (Original 2020)](external/vpx-dcrystalpup) | :x: | :x: | :x: | :white_check_mark: | 60 |
 | [Deadpool, JPs (Original 2021)](external/vpx-deadpool) | :white_check_mark: | :white_check_mark: | :x: | :white_check_mark: | 60 |
 | [Demolition Man (Williams 1994)](external/vpx-demoman) | :white_check_mark: | :white_check_mark: | :white_check_mark: | :x: | 60 |
@@ -434,7 +435,6 @@ Links to these products on Amazon are through affiliate links.
 | [Cyber Race (Original 2023)](external/vpx-cyberrace) | :white_check_mark: | :white_check_mark: | :x: | :x: | 40 |
 | [Cybernaut (Bally 1985)](external/vpx-cybernaut) | :white_check_mark: | :x: | :white_check_mark: | :x: | 45 |
 | [Daredevil and The Defenders (Original 2024)](external/vpx-daredevil) | :white_check_mark: | :white_check_mark: | :x: | :x: | 60 |
-| [Dark Chaos, (Original 2025)](external/vpx-darkchaos) | :white_check_mark: | :x: | :x: | :x: | 60 |
 | [Dark Crystal, The (Original 2020)](external/vpx-darkcrystal) | :white_check_mark: | :white_check_mark: | :x: | :x: | 60 |
 | [DarkPrincess (original 2020)](external/vpx-darkprincess) | :white_check_mark: | :white_check_mark: | :x: | :x: | 57 |
 | [Death Note (Original 2020)](external/vpx-deathnote) | :white_check_mark: | :x: | :x: | :x: | 60 |


### PR DESCRIPTION
I had Dark Chaos in the incorrect manual section of the readme too.  Moving it to wizard tables section

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
