### PR TITLE
feat(manifest): add special-DMD and table-archive fields

### DIFF
--- a/.github/workflows/scripts/validate-table-yaml.py
+++ b/.github/workflows/scripts/validate-table-yaml.py
@@ -189,6 +189,7 @@ CHECKSUM_YAML_KEYS = [
     "diffChecksum",
     "pupChecksum",
     "romChecksum",
+    "specialDMDChecksum",
     "vpxChecksum",
 ]
 
@@ -306,6 +307,168 @@ def check_additional_roms(meta):
         if url_override is not None and entry.get("versionOverride") is None:
             print(f"ERROR: {label} has urlOverride but no versionOverride")
             sys.exit(1)
+
+# Special-DMD packs the wizard knows how to label. specialDMDType is only a
+# display string, but it is validated against this list so a typo doesn't reach a
+# cabinet as a mislabelled row. Add to it when a new DMD format is supported.
+SPECIAL_DMD_TYPES = ["UltraDMD", "FlexDMD"]
+
+ARCHIVE_FORMATS = ["zip", "rar", "7z"]
+
+
+def check_vpx_archive(meta):
+    """Checks the table-archive fields (vpxArchiveFormat / vpxExtractExtra).
+
+    Setting vpxArchiveFormat means the table installs from the archive the author
+    published rather than from a bare .vpx: the wizard's upload slot then accepts
+    only that archive, and the cabinet unpacks the .vpx and any folders the table
+    needs out of it. A table needs this whenever something it loads at run time
+    is a FOLDER - an UltraDMD/FlexDMD pack, a music folder - because an upload
+    slot can only carry files.
+
+    Two consequences are checked here:
+      * vpxChecksum must list at least two hashes. It stays an unordered set of
+        accepted hashes, as everywhere else; it just has to contain both the
+        archive's MD5 (which is what admits the upload) and the .vpx's (which is
+        what picks the table out of the archive, since a download often carries
+        several cuts).
+      * vpxExtractExtra is only meaningful with it, and each entry must be a
+        relative path inside the archive.
+
+    Args:
+      meta: The table metadata.
+
+    Returns:
+      None
+    """
+    print("Checking table archive...")
+    for table, table_meta in meta.items():
+        archive_format = table_meta.get("vpxArchiveFormat")
+        extras = table_meta.get("vpxExtractExtra")
+
+        if archive_format is not None and archive_format not in ARCHIVE_FORMATS:
+            print(
+                f"ERROR: vpxArchiveFormat '{archive_format}' is not one of "
+                f"{', '.join(ARCHIVE_FORMATS)} in table: {table}"
+            )
+            sys.exit(1)
+
+        if archive_format is None:
+            if extras:
+                print(
+                    f"ERROR: vpxExtractExtra needs vpxArchiveFormat - there is no archive "
+                    f"to extract from without it in table: {table}"
+                )
+                sys.exit(1)
+            continue
+
+        if len(table_meta.get("tableChecksum") or []) < 2:
+            print(
+                f"ERROR: vpxArchiveFormat is set but vpxChecksum lists one hash - it must "
+                f"list the table archive's MD5 as well as the .vpx's in table: {table}"
+            )
+            sys.exit(1)
+
+        for path in extras or []:
+            if not isinstance(path, str) or not path.strip():
+                print(f"ERROR: vpxExtractExtra has an empty entry in table: {table}")
+                sys.exit(1)
+            if path.startswith("/") or ".." in Path(path).parts:
+                print(
+                    f"ERROR: vpxExtractExtra entry '{path}' must be a relative path inside "
+                    f"the archive in table: {table}"
+                )
+                sys.exit(1)
+
+
+def check_special_dmd(meta):
+    """Checks the special-DMD (UltraDMD / FlexDMD) fields.
+
+    The pack reaches a cabinet in one of two shapes, with different rules:
+
+      * standalone - the pack is its own archive, so specialDMDChecksum is
+        required. specialDMDUrlOverride is optional: with no override the wizard
+        sends the user to the table's own download page, where the pack usually
+        sits beside the table.
+      * bundled - the folder is inside the table download, so there is no
+        separate file to hash. It therefore requires vpxArchiveFormat, which
+        turns the install into an archive install (see check_vpx_archive), and
+        specialDMDArchiveRoot names the folder the cabinet unpacks out of it. A
+        specialDMDChecksum here would cover nothing, so it is rejected rather
+        than quietly ignored.
+
+    specialDMDType is required either way - it is the label the wizard row and
+    the upload slot carry. specialDMDNSFW works in both shapes: a standalone pack
+    is filtered out by not uploading it, and a bundled one by telling the cabinet
+    not to unpack that folder from the table archive.
+
+    Args:
+      meta: The table metadata.
+
+    Returns:
+      None
+    """
+    print("Checking special DMD...")
+    dmd_fields = (
+        "specialDMDArchiveFormat",
+        "specialDMDArchiveRoot",
+        "specialDMDChecksum",
+        "specialDMDFileUrl",
+        "specialDMDNotes",
+        "specialDMDType",
+        "specialDMDVersion",
+    )
+
+    for table, table_meta in meta.items():
+        bundled = bool(table_meta.get("specialDMDBundled"))
+        if not bundled and not any(table_meta.get(f) is not None for f in dmd_fields):
+            continue
+
+        dmd_type = table_meta.get("specialDMDType")
+        if dmd_type is None:
+            print(f"ERROR: specialDMDType field not found in table: {table}")
+            sys.exit(1)
+        if dmd_type not in SPECIAL_DMD_TYPES:
+            print(
+                f"ERROR: specialDMDType '{dmd_type}' is not one of "
+                f"{', '.join(SPECIAL_DMD_TYPES)} in table: {table}"
+            )
+            sys.exit(1)
+
+        fmt_value = table_meta.get("specialDMDArchiveFormat")
+        if fmt_value is not None and fmt_value not in ARCHIVE_FORMATS:
+            print(
+                f"ERROR: specialDMDArchiveFormat '{fmt_value}' is not one of "
+                f"{', '.join(ARCHIVE_FORMATS)} in table: {table}"
+            )
+            sys.exit(1)
+
+        if bundled:
+            if table_meta.get("specialDMDArchiveRoot") is None:
+                print(
+                    f"ERROR: specialDMDBundled is True but specialDMDArchiveRoot "
+                    f"(the folder to unpack from the table archive) is not found in table: {table}"
+                )
+                sys.exit(1)
+
+            if table_meta.get("vpxArchiveFormat") is None:
+                print(
+                    f"ERROR: specialDMDBundled is True but vpxArchiveFormat is not found in table: {table}"
+                )
+                sys.exit(1)
+
+            if table_meta.get("specialDMDChecksum") is not None:
+                print(
+                    f"ERROR: specialDMDBundled is True, so the folder has no file to hash - "
+                    f"put the table archive's MD5 in vpxChecksum instead of specialDMDChecksum "
+                    f"in table: {table}"
+                )
+                sys.exit(1)
+
+        elif table_meta.get("specialDMDChecksum") is None:
+            print(f"ERROR: specialDMDChecksum field not found in table: {table}")
+            sys.exit(1)
+
 
 def check_fixes(meta):
     """Checks if the applyFixes field is valid.
@@ -470,6 +633,8 @@ if __name__ == "__main__":
 
     check_bundled(meta)
     check_checksums(meta)
+    check_vpx_archive(meta)
+    check_special_dmd(meta)
     check_fixes(meta)
     check_fps(meta)
     check_testers(meta)

--- a/.github/workflows/scripts/vpsdb.py
+++ b/.github/workflows/scripts/vpsdb.py
@@ -64,6 +64,19 @@ def normalize_checksums(value):
     return normalized or None
 
 
+def as_str_list(value):
+    """Normalize a field that may be a single string or a list of strings into a
+    list of strings. Absent/empty becomes None so the manifest simply omits it.
+    Used by vpxExtractExtra, which is authored as a list of archive paths.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = [value]
+    normalized = [str(item) for item in value if item]
+    return normalized or None
+
+
 def normalize_dict_list(value):
     """Normalize a field that may be a single mapping or a list of mappings
     into a list of mappings. Absent/None becomes an empty list. Used by the
@@ -327,6 +340,7 @@ def get_table_meta(files, warn_on_error=True):
         romChecksum = normalize_checksums(data.get("romChecksum"))
         vpxChecksum = normalize_checksums(data.get("vpxChecksum"))
         pupChecksum = normalize_checksums(data.get("pupChecksum"))
+        specialDMDChecksum = normalize_checksums(data.get("specialDMDChecksum"))
 
         table_meta = {
             "altSoundAuthors": data.get("altSoundAuthorsOverride"),
@@ -387,6 +401,34 @@ def get_table_meta(files, warn_on_error=True):
             "romNotes": data.get("romNotes"),
             "romVersion": data.get("romVersionOverride"),
             "romNSFW": data.get("romNSFW"),
+            # Special DMD (UltraDMD / FlexDMD): the DMD content folder a
+            # table's script loads at run time, installed into the ROOT of the
+            # table folder. VPS has no category for these, so there is no id to
+            # resolve — every field is authored here and passed through.
+            #
+            # specialDMDFileUrl is an OVERRIDE only: the pack is normally one of
+            # the files on the table's own download page, so with no override the
+            # wizard sends the user to the table's mirrors. When
+            # specialDMDBundled is set the folder is inside the table download
+            # itself and there is nothing to link at all — the wizard uploads
+            # that archive (vpxArchiveFormat) and the device unpacks the folder
+            # named by specialDMDArchiveRoot out of it.
+            "specialDMDArchiveFormat": data.get("specialDMDArchiveFormat"),
+            "specialDMDArchiveRoot": data.get("specialDMDArchiveRoot"),
+            "specialDMDBundled": data.get("specialDMDBundled"),
+            "specialDMDChecksum": specialDMDChecksum,
+            "specialDMDFileUrl": as_url_list(data.get("specialDMDUrlOverride")),
+            "specialDMDNotes": data.get("specialDMDNotes"),
+            "specialDMDNSFW": data.get("specialDMDNSFW"),
+            "specialDMDType": data.get("specialDMDType"),
+            "specialDMDVersion": data.get("specialDMDVersion"),
+            # vpxArchiveFormat means the table installs from the archive the
+            # author published rather than a bare .vpx: the wizard's upload slot
+            # takes only that format, and the cabinet unpacks the .vpx (picked by
+            # checksum) plus every folder listed in vpxExtractExtra - run-time
+            # media like "Music" that the table loads from its own folder.
+            "vpxArchiveFormat": data.get("vpxArchiveFormat"),
+            "vpxExtractExtra": as_str_list(data.get("vpxExtractExtra")),
             "tableChecksum": vpxChecksum,
             "tableNotes": data.get("tableNotes"),
             "tagline": data.get("tagline"),

--- a/doc/advanced/wizardtable.adoc
+++ b/doc/advanced/wizardtable.adoc
@@ -74,8 +74,19 @@ tableNameOverride:           | [String]
 tableNotes:                  | [String]
 tableVPSId:                  | [String]
 tagline:                     | [String]
+specialDMDArchiveFormat:     | [String]
+specialDMDArchiveRoot:       | [String]
+specialDMDBundled:           | [Bool]
+specialDMDChecksum:          | [String]
+specialDMDNotes:             | [String]
+specialDMDNSFW:              | [Bool]
+specialDMDType:              | [String]
+specialDMDUrlOverride:       | [String]
+specialDMDVersion:           | [String]
 testers:                     | [Array]
+vpxArchiveFormat:            | [String]
 vpxChecksum:                 | [String]
+vpxExtractExtra:             | [Array]
 vpxNSFW:                     | [Bool]
 vpxVPSId:                    | [String]
 ....
@@ -85,7 +96,7 @@ that you need to know to use successfully!
 
 ....
 ########################
-NSFW / adult content (nsfw / vpxNSFW / backglassNSFW / romNSFW / coloredROMNSFW / altSoundNSFW / pupNSFW / diffNSFW)
+NSFW / adult content (nsfw / vpxNSFW / backglassNSFW / romNSFW / coloredROMNSFW / altSoundNSFW / pupNSFW / diffNSFW / specialDMDNSFW)
 ########################
 
 Type:
@@ -109,15 +120,16 @@ that has any flag set.
 - altSoundNSFW: [Bool] the altsound pack is adult.
 - pupNSFW: [Bool] the pup videos are adult.
 - diffNSFW: [Bool] the VPU patch adds adult content.
+- specialDMDNSFW: [Bool] the UltraDMD/FlexDMD pack is adult.
 
 When the wizard user has NOT enabled NSFW:
 
 - A table flagged nsfw, vpxNSFW, backglassNSFW or romNSFW is hidden from the
   wizard listing entirely — those parts can't be skipped, so the whole table is
   withheld.
-- A table with only coloredROMNSFW, altSoundNSFW, pupNSFW or diffNSFW set still
-  installs, but that component is filtered out of the install (its upload slot /
-  download is not shown and it is not required).
+- A table with only coloredROMNSFW, altSoundNSFW, pupNSFW, diffNSFW or
+  specialDMDNSFW set still installs, but that component is filtered out of the
+  install (its upload slot / download is not shown and it is not required).
 
 Example:
 ------------
@@ -1158,6 +1170,96 @@ Gotchas:
 
 ....
 ########################
+specialDMD (specialDMDType / specialDMDBundled / ...)
+########################
+
+Type:
+------------
+Group of fields (see below)
+
+Description:
+------------
+A "special DMD" is the DMD content folder a table's script loads at run time —
+an UltraDMD or FlexDMD pack, e.g. "MyTable.UltraDMD". It is installed into the
+ROOT of the table folder, beside the installed .vpx, because that is where the
+script looks for it. specialDMDType says which of the two it is and is the label
+the wizard puts on the row and the upload slot; it is REQUIRED whenever any
+specialDMD field is set, and must be exactly "UltraDMD" or "FlexDMD".
+
+VPS has no file category for these packs, so nothing is resolved from it: there
+is no specialDMDVPSId, no resolved authors or version, and no "report broken
+link" button on the row.
+
+There are TWO shapes, and they have different rules.
+
+STANDALONE — the pack is its own archive. It is normally just another file on
+the table's own download page, so specialDMDUrlOverride is an OVERRIDE only:
+leave it unset and the wizard points the user at the table's mirrors.
+specialDMDChecksum is REQUIRED, and the wizard verifies the upload against it.
+
+- specialDMDType: [String] REQUIRED. "UltraDMD" or "FlexDMD".
+- specialDMDChecksum: [String|List] MD5(s) of the pack archive. REQUIRED here.
+  One hash -> a string; two or more -> a YAML list.
+- specialDMDUrlOverride: [String] only when the pack is NOT on the table's own
+  download page.
+- specialDMDVersion: [String] version shown on the wizard row.
+- specialDMDNotes: [String] Markdown notes shown on the wizard row.
+- specialDMDArchiveFormat: [String] zip | rar | 7z. Default: zip. Only sets the
+  wizard's file picker filter; extraction auto-detects the real format.
+- specialDMDArchiveRoot: [String] the folder INSIDE the archive to install. Leave
+  it unset when the archive already holds the pack folder at its top level.
+- specialDMDNSFW: [Bool] the pack is adult content (filtered out when the
+  wizard's NSFW toggle is off; the table still installs).
+
+BUNDLED — the folder is inside the table download itself. An upload slot can
+only carry files, never a folder, so the wizard uploads the WHOLE table archive
+and the cabinet unpacks both halves from it: the .vpx, picked by MD5, and the
+folder named by specialDMDArchiveRoot.
+
+- specialDMDBundled: [Bool] true.
+- specialDMDArchiveRoot: [String] REQUIRED. The folder to unpack from the table
+  archive, e.g. "MyTable.FlexDMD". The install fails if the archive has no such
+  folder.
+- vpxArchiveFormat: [String] REQUIRED — this is an archive install. See the
+  "vpxArchiveFormat / vpxExtractExtra" section below for it and the two-hash
+  vpxChecksum it brings with it.
+- specialDMDChecksum: NOT allowed here — a folder has no single hash, and the
+  archive's hash belongs in vpxChecksum.
+- specialDMDNSFW: works here as it does for a standalone pack. The table archive
+  is still uploaded and the table still installs; the cabinet is simply told not
+  to unpack the folder.
+
+Example:
+------------
+# standalone
+specialDMDType: "UltraDMD"
+specialDMDChecksum: "00000000000000000000000000000000"
+specialDMDArchiveRoot: "MyTable.UltraDMD"
+
+# bundled in the table download
+specialDMDType: "FlexDMD"
+specialDMDBundled: true
+specialDMDArchiveRoot: "MyTable.FlexDMD"
+vpxArchiveFormat: "zip"
+vpxChecksum:                             # order does not matter
+  - "00000000000000000000000000000000"   # the table archive
+  - "11111111111111111111111111111111"   # the .vpx inside it
+
+Gotchas:
+------------
+- specialDMDArchiveRoot names the FOLDER itself, not its parent. The folder is
+  recreated under that name in the table folder, however deeply the archive
+  nested it.
+- For a bundled pack, testers must upload the archive they downloaded — not the
+  .vpx they extracted from it. The wizard's slot only accepts the archive, and
+  the "wrong" hash (the .vpx's) is in vpxChecksum too, so both are accepted at
+  upload time; the cabinet then fails a .vpx-only upload with a clear error.
+- Once a pack is declared it is required, the same way altsound is. There is no
+  specialDMDRequired.
+....
+
+....
+########################
 vpxChecksum
 ########################
 
@@ -1178,6 +1280,67 @@ Gotchas:
 ------------
 - I know this sounds silly... but double check you've definitely selected the right file in QuickHash!
   Often the biggest mistake on these checksum fields were from getting a checksum of the wrong file :)
+....
+
+....
+########################
+vpxArchiveFormat / vpxExtractExtra
+########################
+
+Type:
+------------
+String / Array
+
+Description:
+------------
+Set vpxArchiveFormat when the table must be installed from the ARCHIVE the
+author published rather than from a bare .vpx. A table needs that whenever
+something it loads at run time is a FOLDER — an UltraDMD/FlexDMD pack, a music
+folder — because a wizard upload slot can only carry files, never a folder.
+
+The wizard's vpx slot then accepts only that archive (a .vpx is refused), and the
+cabinet unpacks, in one pass: the .vpx, picked by MD5; every folder listed in
+vpxExtractExtra; and, for a bundled pack, specialDMDArchiveRoot. Each folder is
+recreated in the ROOT of the table folder under its own name, with everything
+below it intact.
+
+- vpxArchiveFormat: [String] zip | rar | 7z.
+- vpxExtractExtra: [Array] extra folders to install into the table root. Each is
+  a relative path inside the archive; a single folder may be written as a plain
+  string. Requires vpxArchiveFormat.
+- vpxChecksum: [List] with vpxArchiveFormat set this must list BOTH the archive's
+  MD5 and the .vpx's. As everywhere else it is an unordered set of accepted
+  hashes, so list them in either order: one of them lets the upload through, and
+  one of them picks the .vpx out of the archive (a download often carries several
+  .vpx cuts).
+
+Example:
+------------
+# an archive laid out as
+#   MyTable v1.2.vpx
+#   Music/MFDOOM/Attract1.mp3
+#   Music/MFDOOM/Attract2.mp3
+vpxArchiveFormat: "zip"
+vpxExtractExtra:
+  - "Music"
+vpxChecksum:                             # order does not matter
+  - "00000000000000000000000000000000"   # the table archive
+  - "11111111111111111111111111111111"   # the .vpx inside it
+
+# installs as
+#   <table folder>/vpx-mytable.vpx
+#   <table folder>/Music/MFDOOM/Attract1.mp3
+#   <table folder>/Music/MFDOOM/Attract2.mp3
+
+Gotchas:
+------------
+- Every folder asked for must be in the archive. A missing one fails the install
+  (naming it) rather than quietly producing a table with no music — so check the
+  spelling and case against the archive listing.
+- Each entry names the FOLDER, not its parent and not its contents: "Music"
+  installs <table>/Music/..., and "Media/Music" also installs <table>/Music/...
+- Testers must upload the archive they downloaded, not the .vpx they extracted
+  from it. The slot only offers the archive.
 ....
 
 ....

--- a/table.yml.example
+++ b/table.yml.example
@@ -168,6 +168,53 @@ testers:
 # altSoundNSFW: false                             # [Boolean] altsound is adult (filtered out when NSFW is off; table still installs)
 
 
+# --- Table archive (optional) ------------------------------------------------
+# Set vpxArchiveFormat when the table must be installed from the archive the
+# author published instead of a bare .vpx — i.e. whenever it needs whole FOLDERS
+# out of that download, since an upload slot can only carry files. The wizard's
+# vpx slot then accepts only that archive, and the cabinet unpacks the .vpx
+# (picked by checksum) plus every folder asked for.
+#
+# vpxChecksum must then list BOTH the archive's md5 and the .vpx's, in any order:
+# one admits the upload, the other picks the table out of the archive.
+# vpxArchiveFormat: "zip"                         # [String] zip | rar | 7z
+# vpxExtractExtra:                                # [List] extra folders to install into the table root
+#   - "Music"                                     #        e.g. Music/MFDOOM/*.mp3 -> <table>/Music/MFDOOM/*.mp3
+# vpxChecksum:                                    # [List] the archive's md5 AND the .vpx's (any order)
+#   - "00000000000000000000000000000000"
+#   - "11111111111111111111111111111111"
+
+
+# --- Special DMD: UltraDMD / FlexDMD (optional) ------------------------------
+# The DMD content folder (e.g. "MyTable.UltraDMD") a table's script loads at run
+# time. It is installed into the ROOT of the table folder, beside the .vpx.
+# VPS has no category for these, so nothing is resolved — every field is set
+# here. specialDMDType is REQUIRED: it is the label the wizard shows.
+# There is no "required" flag; once declared, the wizard requires it.
+#
+# TWO SHAPES. Pick one:
+#
+# 1) STANDALONE — the pack is its own archive, usually another file on the
+#    table's download page. specialDMDChecksum is REQUIRED. Leave the url unset
+#    and the wizard sends the user to the table's own mirrors.
+# specialDMDType: "UltraDMD"                      # [String] UltraDMD | FlexDMD — REQUIRED
+# specialDMDChecksum: "00000000000000000000000000000000"   # [String|List] REQUIRED for a standalone pack
+# specialDMDUrlOverride: "https://..."            # [String] only when the pack is NOT on the table's page
+# specialDMDVersion: "1.0"                        # [String]
+# specialDMDNotes: "Markdown notes."              # [String]
+# specialDMDArchiveFormat: "zip"                  # [String] zip | rar | 7z  (default: zip)
+# specialDMDArchiveRoot: "MyTable.UltraDMD"       # [String] the folder INSIDE the archive to install
+# specialDMDNSFW: false                           # [Boolean] pack is adult (filtered out when NSFW is off; table still installs)
+#
+# 2) BUNDLED — the folder is inside the table download itself, so this is an
+#    archive install: it REQUIRES vpxArchiveFormat and the two-hash vpxChecksum
+#    from the "Table archive" section above. specialDMDChecksum is not allowed
+#    (a folder has no single hash).
+# specialDMDType: "FlexDMD"                       # [String] UltraDMD | FlexDMD — REQUIRED
+# specialDMDBundled: true                         # [Boolean] the folder ships inside the table download
+# specialDMDArchiveRoot: "MyTable.FlexDMD"        # [String] REQUIRED — the folder to unpack from the table archive
+
+
 # --- Tutorial (optional) ----------------------------------------------------
 # tutorialVPSId: "xxxxxxxx"                       # [String] resolves title / YouTube ID
 


### PR DESCRIPTION
specialDMD* carries an UltraDMD or FlexDMD pack: the DMD content folder a table's script loads at run time, installed into the root of the table folder. VPS has no file category for these, so nothing is resolved from it — specialDMDType names the format for the wizard's label, and the pack is either its own archive (specialDMDChecksum required) or bundled inside the table download.

specialDMDUrlOverride is an override only. The pack is normally another file on the table's own download page, so with no override the wizard sends the user to the table's mirrors rather than repeating them in every entry.

vpxArchiveFormat marks a table installed from the archive the author published instead of a bare .vpx, which is what a bundled pack needs: an upload slot can only carry files, never a folder. vpxChecksum then has to list the archive's MD5 as well as the .vpx's — still an unordered set of accepted hashes, one admitting the upload and one picking the table out of the archive. vpxExtractExtra lifts further folders out of that same archive (run-time media such as "Music").

validate-table-yaml enforces the split: type required and known, checksum required for a standalone pack and refused for a bundled one (a folder has no single hash), archiveRoot and vpxArchiveFormat required when bundled, and vpxExtractExtra entries confined to relative paths inside the archive.

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
