### PR TITLE
feat: add 'Coffee' Joe to team favorites and order Wizard-only roles …

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,14 @@ Table Manager's Add Tables wizard — a curated "start here" list, shown as one 
 team member. It is read straight from this repo (latest release tag, falling back to
 `main`), so an edit here reaches cabinets without a Table Manager release.
 
-The file is a plain array. To add yourself, append an entry:
+The file is a plain array, and **cards are shown in file order** — there is no
+sorting on the device, so the order here is the order players see. Add yourself
+in the appropriate place rather than always at the end: entries whose role is
+*only* `Wizard` go last, after everyone else. A compound role that happens to
+contain the word (`Wizard Wrangler / Community Manager`) is not one of these and
+sits with the rest.
+
+An entry looks like:
 
 ```json
 [

--- a/team_favorites.json
+++ b/team_favorites.json
@@ -40,13 +40,13 @@
     ]
   },
   {
-    "member": "Bla1ze",
-    "avatar": "https://cdn.discordapp.com/avatars/488775261534289920/5f73c634780b6ff8172319ae8eb91890.png",
-    "role": "Wizard",
+    "member": "'Coffee' Joe",
+    "avatar": "https://cdn.discordapp.com/avatars/735556812862128158/40ccbffae4b299b34e99967ea97a1bf3.png",
+    "role": "Art Department Head",
     "tables": [
-      "vpx-bigbangbar",
-      "vpx-tommy",
-      "vpx-sopranos"
+      "vpx-mousin",
+      "vpx-hardbody",
+      "vpx-cftbl"
     ]
   },
   {
@@ -57,6 +57,16 @@
       "vpx-sopranos",
       "vpx-spacecadetge",
       "vpx-tna"
+    ]
+  },
+  {
+    "member": "Bla1ze",
+    "avatar": "https://cdn.discordapp.com/avatars/488775261534289920/5f73c634780b6ff8172319ae8eb91890.png",
+    "role": "Wizard",
+    "tables": [
+      "vpx-bigbangbar",
+      "vpx-tommy",
+      "vpx-sopranos"
     ]
   }
 ]


### PR DESCRIPTION
…last

Adds 'Coffee' Joe (Art Department Head) with Mousin' Around!, Hardbody and Creature from the Black Lagoon.

Moves Bla1ze to the end: a member whose role is only "Wizard" now sorts after everyone else. Mox is unaffected — "Wizard Wrangler / Community Manager" is a compound role that merely contains the word, not a Wizard-only one.

Nothing sorts this list on the device, so file order is display order. That made the README's own advice ("append an entry") wrong the moment the rule existed, since appending now lands you after the Wizards. It documents the ordering instead, including the compound-role exception.

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
