### PR TITLE
feat: add Silentkat to team favorites, and state the Wizard rule corr…

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,13 @@ team member. It is read straight from this repo (latest release tag, falling bac
 
 The file is a plain array, and **cards are shown in file order** — there is no
 sorting on the device, so the order here is the order players see. Add yourself
-in the appropriate place rather than always at the end: entries whose role is
-*only* `Wizard` go last, after everyone else. A compound role that happens to
-contain the word (`Wizard Wrangler / Community Manager`) is not one of these and
-sits with the rest.
+in the appropriate place rather than always at the end.
+
+`role` is a `/`-separated list of roles, and **anyone holding the `Wizard` role
+goes last**, after everyone else. Match whole values, not substrings:
+`Wizard / PUP Sorcerer` holds it and belongs at the end, while
+`Wizard Wrangler / Community Manager` does not — `Wizard Wrangler` is a role in
+its own right.
 
 An entry looks like:
 
@@ -37,7 +40,7 @@ An entry looks like:
 |:-----:|:--------:|:-----------:|
 | `member` | :white_check_mark: | Display name shown on the card |
 | `tables` | :white_check_mark: | Folder names under `external/`, **not** table display names |
-| `role` | :x: | Free text shown under the name, e.g. "Lead Developer" |
+| `role` | :x: | Roles held, `/`-separated, shown under the name — e.g. "Lead Developer" or "Wizard / PUP Sorcerer". Holding `Wizard` decides ordering, see above |
 | `avatar` | :x: | Image URL; a person icon is shown when empty or unreachable |
 
 Each table's box art is its own `external/<name>/launcher.png`, and its display name,

--- a/team_favorites.json
+++ b/team_favorites.json
@@ -68,5 +68,15 @@
       "vpx-tommy",
       "vpx-sopranos"
     ]
+  },
+  {
+    "member": "Silentkat",
+    "avatar": "https://cdn.discordapp.com/avatars/542903512959549470/520a604ebbfd0b78ee3c3848f35676f6.png",
+    "role": "Wizard / PUP Sorcerer",
+    "tables": [
+      "vpx-dcrystalpup",
+      "vpx-2001",
+      "vpx-deadpool"
+    ]
   }
 ]


### PR DESCRIPTION
…ectly

Adds Silentkat (Wizard / PUP Sorcerer) with The Dark Crystal Pinball, 2001 - A Space Odyssey and Deadpool, placed at the end alongside Bla1ze.

That placement is what exposed the previous wording as wrong. `role` is a `/`-separated list of roles, so the test for "goes last" is whether any whole value equals Wizard — not whether the string contains the word, and not whether the role is *only* Wizard. Both readings the README offered before broke on a real entry: "Wizard / PUP Sorcerer" holds the Wizard role and belongs at the end, while "Wizard Wrangler / Community Manager" does not, because Wizard Wrangler is a role in its own right. Both are now the worked examples.

The file order already satisfied the corrected rule, so no card moved; only the documentation changed. The role field's own description said "free text", which undersold a field the ordering now depends on.

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
