### PR TITLE
feat: add GamerDad89 to team favorites

### DIFF
--- a/team_favorites.json
+++ b/team_favorites.json
@@ -60,6 +60,16 @@
     ]
   },
   {
+    "member": "GamerDad89",
+    "avatar": "https://cdn.discordapp.com/avatars/1325826626134478880/070162d5acd9cb59f515a7af2167f6b0.png",
+    "role": "Tournament Coordinator",
+    "tables": [
+      "vpx-bop",
+      "vpx-xfiles",
+      "vpx-spacecadetge"
+    ]
+  },
+  {
     "member": "Bla1ze",
     "avatar": "https://cdn.discordapp.com/avatars/488775261534289920/5f73c634780b6ff8172319ae8eb91890.png",
     "role": "Wizard",


### PR DESCRIPTION
Tournament Coordinator, placed before Bla1ze and Silentkat so the Wizard-only roles stay last.

Titles resolved to wizard ids against this repo:
  Machine - Bride of Pin-bot, The (Williams 1991) -> vpx-bop
  X Files (Sega 1997)                             -> vpx-xfiles
  Space Cadet, JP's - Galaxy Edition (2021)       -> vpx-spacecadetge

X Files is the unhyphenated Sega 1997 cut; vpx-xfileshanibal is a separate table with a near-identical title.

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
