### PR TITLE
Updated twister dmd position to fit fulldmd

### DIFF
--- a/external/vpx-twister/table.ini
+++ b/external/vpx-twister/table.ini
@@ -7,6 +7,10 @@ ScreenWidth = 0.000000
 ScreenHeight = 0.000000
 ScreenInclination = 0.000000
 ScreenPlayerY = 15.025158
+RaytracedBallShadows = 0
+Refraction = 0
+ForceBloomOff = 1
+ForceAnisotropicFiltering = 1
 
 [TableOverride]
 ViewCabMode = 2
@@ -18,3 +22,13 @@ ViewCabHOfs = 0.000000
 ViewCabVOfs = 0.003178
 ViewCabWindowTop = 288.981812
 ViewCabWindowBot = 80.496216
+
+[Standalone]
+B2SDMDAutoPlaceTarget = DMD
+B2SDMDAutoPlaceOffsetX = -27
+B2SDMDAutoPlaceOffsetY = 0
+B2SDMDAutoPlaceScaleLinked = 0
+B2SDMDAutoPlaceScale = 1.030000
+B2SDMDAutoPlaceScaleY = 1.000000
+4kpVLMGIKeepPercent = 100
+4kpVLMBakeBrightness = 1.000000


### PR DESCRIPTION
Fixed:
<img width="1280" height="704" alt="drm_0_193-2026-09-05T12-09-44" src="https://github.com/user-attachments/assets/9097cad2-cde5-4a07-8a12-4f7f43dcebd4" />
