### PR TITLE
feat: add editors_picks.json

### DIFF
--- a/editors_picks.json
+++ b/editors_picks.json
@@ -1,0 +1,22 @@
+[
+  "vpx-jpattackfrommars",
+  "vpx-tz",
+  "vpx-mm",
+  "vpx-getaway",
+  "vpx-t2",
+  "vpx-jpseawitch",
+  "vpx-acdcprovault",
+  "vpx-xmen",
+  "vpx-ironmaidenlotb",
+  "vpx-got",
+  "vpx-metallicapremium",
+  "vpx-tna",
+  "vpx-spacecadetge",
+  "vpx-johnwick",
+  "vpx-volkan",
+  "vpx-baywatch",
+  "vpx-twister",
+  "vpx-starwarstrilogy",
+  "vpx-jurassicpark",
+  "vpx-lethalweapon3"
+]


### PR DESCRIPTION
A hand-picked shortlist of twenty tables, read by Table Manager for the Editor's Picks section on What's Hot. Sits beside team_favorites.json and is loaded the same way, straight from the repo tree, so the list can be re-cut without shipping a Table Manager release.

Wizard keys only, in pick order. Everything a card shows — title, manufacturer, year, box art — already comes from the manifest entry each key resolves to, and repeating it here would only let the two drift.

<!--
Please ensure your PR includes the following:

- README.md
- launcher.png
- launcher.xml
- pinmame/cfg, pinmame/ini, pinmame/nvram, pinmame/roms folders. If they are empty, create a .gitkeep file to ensure the folders get created in the repo.
- any game specific ini or vbs files named exactly the same as the publicly available files from either VPForums or VPUniverse

Please ensure your PR **DOES NOT** include any of the following:

- VPX files
- ROMs
- PUP Media files
- Any sort of licensing text that goes against the licensing of this repository

By submitting this PR, you are agreeing that any artwork submitted is your own, or you have the legal right to distribute such artwork.
-->
