### PR TITLE
Publish wizard catalog data for CORS-safe browser fetches

### DIFF
--- a/.github/workflows/create-external-releases.yml
+++ b/.github/workflows/create-external-releases.yml
@@ -93,7 +93,7 @@ jobs:
 
       - name: Table Manager Achievements Config
         run: gh release upload "$GITHUB_REF_NAME" tm-config/achievements.json --clobber
-        
+
       - name: Open PR for README updates
         if: github.event_name == 'release'
         run: |

--- a/.github/workflows/publish-catalog-data.yml
+++ b/.github/workflows/publish-catalog-data.yml
@@ -55,12 +55,23 @@ jobs:
           echo "tag=$tag" >> "$GITHUB_OUTPUT"
           echo "Publishing catalog data for release $tag"
 
-      # Only external/*/launcher.png at this tag is needed (for box art); no
-      # history required, unlike the release-generation workflow.
-      - name: Checkout release tag
+      # This workflow's own scripts — always from wherever it's defined (the
+      # ref that triggered this run, typically main), NOT from the release
+      # tag below. That tag can be much older than this workflow (this is
+      # re-dispatchable for any past release), so checking IT out first would
+      # overwrite the working directory and lose scripts that didn't exist
+      # yet at that tag.
+      - name: Checkout workflow scripts
+        uses: actions/checkout@v5
+
+      # external/*/launcher.png as of the release being published, into a
+      # separate path so it doesn't clobber the checkout above. No history
+      # required here, unlike the release-generation workflow.
+      - name: Checkout release tag (for box art source images)
         uses: actions/checkout@v5
         with:
           ref: ${{ steps.rel.outputs.tag }}
+          path: release-checkout
           fetch-depth: 1
           filter: blob:none
           submodules: false
@@ -88,7 +99,10 @@ jobs:
       # small-thumbnail variant: 145 KB is already small enough for a
       # ~300-table page, and the browser caches it across every use.
       - name: Generate box art
-        run: python .github/workflows/scripts/generate-boxart.py --out /tmp/catalog-publish/boxart
+        run: |
+          python .github/workflows/scripts/generate-boxart.py \
+            --external-dir release-checkout/external \
+            --out /tmp/catalog-publish/boxart
 
       # Trims vpinmediadb's ~1156-table index down to the ~300 wizard tables and
       # re-encodes each 1k bg/table/fss PNG (~1080p, ~3 MB) as a 960x540 WebP

--- a/.github/workflows/publish-catalog-data.yml
+++ b/.github/workflows/publish-catalog-data.yml
@@ -1,0 +1,121 @@
+name: Publish Catalog Data (CORS mirror)
+
+# tm-installer's public Wizard Catalog page reads manifest.json, table-history.json,
+# achievements.json, a full-size WebP re-encode of each table's box art, and a
+# trimmed vpinmediadb-compatible index of WebP backglass/playfield/FSS art
+# (wizard tables only) straight from the browser. GitHub release assets send
+# no CORS headers at all — confirmed:
+# release-assets.githubusercontent.com (what releases/latest/download/... and even
+# api.github.com's asset-download endpoint both redirect to) sends no
+# Access-Control-Allow-Origin, so a browser fetch of a release asset is silently
+# blocked even though curl or a server-side fetch works fine.
+# raw.githubusercontent.com does send `Access-Control-Allow-Origin: *`, so this
+# mirrors the data onto a "manifest" branch instead.
+#
+# That branch exists ONLY for this mirror — every run replaces it with a single
+# fresh orphan commit (force-pushed) rather than accumulating one commit per
+# release. Re-encoding unchanged launcher.png source images is verified
+# byte-for-byte deterministic given a pinned Pillow version, so this would be
+# safe to make incremental too, but there's no reason to carry history a
+# CORS-fetch-only branch never needs to diff against.
+#
+# Runs automatically after "Create External Folder Releases and Manifest"
+# finishes publishing a release's assets (chained via workflow_run so it can't
+# race the upload). Can also be triggered manually — Actions tab -> this
+# workflow -> Run workflow — to re-publish the mirror for the latest release,
+# or a specific tag, without re-running the whole zip/manifest pipeline.
+
+permissions:
+  contents: write
+
+on:
+  workflow_run:
+    workflows: ["Create External Folder Releases and Manifest"]
+    types: [completed]
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: 'Release tag to publish (blank = latest release)'
+        required: false
+
+jobs:
+  publish:
+    if: ${{ github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success' }}
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+    steps:
+      - name: Resolve release tag
+        id: rel
+        run: |
+          tag="${{ inputs.release_tag }}"
+          if [ -z "$tag" ]; then
+            tag=$(gh release view --repo "${{ github.repository }}" --json tagName -q .tagName)
+          fi
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
+          echo "Publishing catalog data for release $tag"
+
+      # Only external/*/launcher.png at this tag is needed (for box art); no
+      # history required, unlike the release-generation workflow.
+      - name: Checkout release tag
+        uses: actions/checkout@v5
+        with:
+          ref: ${{ steps.rel.outputs.tag }}
+          fetch-depth: 1
+          filter: blob:none
+          submodules: false
+          lfs: false
+
+      - name: Set up Python 3.11 (with pip cache)
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: '.github/workflows/scripts/requirements-catalog-publish.txt'
+
+      - name: Install Python dependencies
+        run: pip install -r .github/workflows/scripts/requirements-catalog-publish.txt
+
+      - name: Download release assets
+        run: |
+          rm -rf /tmp/catalog-publish
+          gh release download "${{ steps.rel.outputs.tag }}" \
+            -p manifest.json -p table-history.json -p achievements.json \
+            --clobber -D /tmp/catalog-publish
+
+      # Full-size WebP re-encode of external/<key>/launcher.png (~640x960,
+      # ~1.2 MB PNG -> ~145 KB WebP q90 measured, no resize). No separate
+      # small-thumbnail variant: 145 KB is already small enough for a
+      # ~300-table page, and the browser caches it across every use.
+      - name: Generate box art
+        run: python .github/workflows/scripts/generate-boxart.py --out /tmp/catalog-publish/boxart
+
+      # Trims vpinmediadb's ~1156-table index down to the ~300 wizard tables and
+      # re-encodes each 1k bg/table/fss PNG (~1080p, ~3 MB) as a 960x540 WebP
+      # (~140 KB measured average) — same index shape as upstream, just far
+      # smaller and hosted where a browser can actually fetch it in bulk.
+      - name: Mirror wizard-relevant vpinmediadb art
+        run: |
+          python .github/workflows/scripts/generate-vpinmdb-mirror.py \
+            --manifest /tmp/catalog-publish/manifest.json \
+            --out /tmp/catalog-publish/vpinmdb-mirror
+
+      - name: Publish as a single fresh commit on the manifest branch
+        run: |
+          rm -rf /tmp/manifest-branch
+          mkdir -p /tmp/manifest-branch
+          cd /tmp/manifest-branch
+          git init -q
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git checkout -q --orphan manifest
+
+          cp /tmp/catalog-publish/manifest.json /tmp/catalog-publish/table-history.json \
+             /tmp/catalog-publish/achievements.json .
+          cp -r /tmp/catalog-publish/boxart .
+          cp /tmp/catalog-publish/vpinmdb-mirror/vpinmdb.json .
+          cp -r /tmp/catalog-publish/vpinmdb-mirror/media .
+
+          git add manifest.json table-history.json achievements.json boxart vpinmdb.json media
+          git commit -q -m "Catalog data as of release ${{ steps.rel.outputs.tag }}"
+          git push --force "https://x-access-token:${GH_TOKEN}@github.com/${{ github.repository }}.git" HEAD:manifest

--- a/.github/workflows/scripts/generate-boxart.py
+++ b/.github/workflows/scripts/generate-boxart.py
@@ -11,6 +11,7 @@ variant needed on top: 145 KB is already small enough for a page listing
 
 Usage:
     python generate-boxart.py --out /tmp/boxart
+    python generate-boxart.py --external-dir release-checkout/external --out /tmp/boxart
 """
 import argparse
 import sys
@@ -18,21 +19,22 @@ from pathlib import Path
 
 from PIL import Image
 
-EXTERNAL_DIR = Path("external")
 QUALITY = 90
 
 
 def main():
     parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--external-dir", default="external", help="directory containing <table-key>/launcher.png folders (default: %(default)s)")
     parser.add_argument("--out", required=True, help="output directory for <table-key>.webp files")
     args = parser.parse_args()
 
+    external_dir = Path(args.external_dir)
     out_dir = Path(args.out)
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    sources = sorted(EXTERNAL_DIR.glob("*/launcher.png"))
+    sources = sorted(external_dir.glob("*/launcher.png"))
     if not sources:
-        print(f"No launcher.png files found under {EXTERNAL_DIR}/", file=sys.stderr)
+        print(f"No launcher.png files found under {external_dir}/", file=sys.stderr)
         sys.exit(1)
 
     written = 0

--- a/.github/workflows/scripts/generate-boxart.py
+++ b/.github/workflows/scripts/generate-boxart.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Render every table's launcher.png box art as full-size WebP, for the CORS
+mirror branch only — this never touches the device-installed release zip
+(generate-release.py), which still ships the PNG untouched.
+
+tm-installer's public Wizard Catalog page hot-links this for its list view and
+detail drawer. Re-encoding at q90 with no resize measured ~88% smaller than
+the source PNG (~1.08 MB -> ~145 KB average) with no separate small-thumbnail
+variant needed on top: 145 KB is already small enough for a page listing
+~300 tables, and the browser caches it across every place it's reused.
+
+Usage:
+    python generate-boxart.py --out /tmp/boxart
+"""
+import argparse
+import sys
+from pathlib import Path
+
+from PIL import Image
+
+EXTERNAL_DIR = Path("external")
+QUALITY = 90
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--out", required=True, help="output directory for <table-key>.webp files")
+    args = parser.parse_args()
+
+    out_dir = Path(args.out)
+    out_dir.mkdir(parents=True, exist_ok=True)
+
+    sources = sorted(EXTERNAL_DIR.glob("*/launcher.png"))
+    if not sources:
+        print(f"No launcher.png files found under {EXTERNAL_DIR}/", file=sys.stderr)
+        sys.exit(1)
+
+    written = 0
+    for src in sources:
+        key = src.parent.name
+        dest = out_dir / f"{key}.webp"
+        try:
+            with Image.open(src) as im:
+                im.convert("RGB").save(dest, "WEBP", quality=QUALITY, method=6)
+            written += 1
+        except Exception as e:  # noqa: BLE001 - one bad image shouldn't fail the whole release
+            print(f"[WARN] could not convert {src}: {e}", file=sys.stderr)
+
+    print(f"Wrote {written}/{len(sources)} box-art images to {out_dir}/")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/generate-vpinmdb-mirror.py
+++ b/.github/workflows/scripts/generate-vpinmdb-mirror.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Mirror vpinmediadb's backglass/playfield/FSS art for wizard tables only,
+re-encoded as WebP, into a small vpinmediadb-COMPATIBLE json (same shape:
+{vpsId: {"1k": {"bg": ..., "table": ..., "fss": ...}}}, just far fewer entries
+and WebP URLs instead of vpinmediadb's PNGs) — a drop-in for any consumer that
+already speaks vpinmediadb's index format.
+
+Prefers each table's 1k image; falls back to 4k (resized down, same as
+everything else) when 1k is missing rather than dropping that image — e.g.
+~5 wizard tables only have a 4k.fss. Always published under "1k" in our own
+output regardless of which tier it actually came from, since every consumer
+only ever reads media[id]["1k"][kind] and we resize to one fixed size anyway.
+
+Both tm-installer's Wizard Catalog page and Table Manager's own wizard UI need
+this art, and both currently hot-link vpinmediadb's raw PNGs directly: the
+full upstream index covers ~1156 tables (way more than the ~300 in the
+wizard), and each PNG is ~1080p / ~3 MB. Measured: WebP q90 at 960x540 (the
+largest size anything in either UI actually renders this at) comes out to
+~140 KB average, a ~95% reduction — see the "vpinmdb 1k benchmark" in the
+implementation notes for the full comparison table.
+
+Usage:
+    python generate-vpinmdb-mirror.py --manifest manifest.json --out /tmp/media
+"""
+import argparse
+import json
+import sys
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from io import BytesIO
+from pathlib import Path
+
+import requests
+from PIL import Image
+
+VPINMDB_INDEX_URL = "https://raw.githubusercontent.com/superhac/vpinmediadb/main/vpinmdb.json"
+DEFAULT_BASE_URL = "https://raw.githubusercontent.com/LegendsUnchained/vpx-standalone-alp4k/manifest/media/"
+KINDS = ("bg", "table", "fss")
+SIZE = (960, 540)  # largest CSS size anything in tm-installer or tablemanager-fe renders this at
+QUALITY = 90
+TIMEOUT = 20
+
+
+def fetch_index():
+    resp = requests.get(VPINMDB_INDEX_URL, timeout=30)
+    resp.raise_for_status()
+    return resp.json()
+
+
+def pick_source(entry, kind):
+    """Prefer 1k; fall back to 4k rather than skipping a table's art entirely.
+    Whichever tier is used, we resize down to SIZE anyway, so the source
+    resolution doesn't matter downstream. (bg has no 4k variant in
+    vpinmediadb — checked across all 1156 entries — so this only ever
+    recovers table/fss; measured 5 wizard tables gain an fss this way.)"""
+    for tier in ("1k", "4k"):
+        url = (entry.get(tier) or {}).get(kind)
+        if url:
+            return url, tier
+    return None, None
+
+
+def convert_one(vps_id, kind, url, media_dir):
+    try:
+        resp = requests.get(url, timeout=TIMEOUT)
+        resp.raise_for_status()
+        with Image.open(BytesIO(resp.content)) as im:
+            im = im.convert("RGB")
+            im.thumbnail(SIZE, Image.LANCZOS)
+            dest = media_dir / vps_id / f"{kind}.webp"
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            im.save(dest, "WEBP", quality=QUALITY, method=6)
+        return vps_id, kind, True
+    except Exception as e:
+        print(f"[WARN] {vps_id}/{kind}: {e}", file=sys.stderr)
+        return vps_id, kind, False
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--manifest", required=True, help="wizard manifest.json, to find which vpsdbId values matter")
+    parser.add_argument("--out", required=True, help="output dir: <out>/vpinmdb.json + <out>/media/<id>/<kind>.webp")
+    parser.add_argument("--base-url", default=DEFAULT_BASE_URL, help="public URL prefix media/ is published under (default: %(default)s)")
+    parser.add_argument("--workers", type=int, default=8)
+    args = parser.parse_args()
+
+    manifest = json.loads(Path(args.manifest).read_text())
+    wizard_ids = sorted({t.get("vpsdbId") for t in manifest.values() if t.get("vpsdbId")})
+    print(f"{len(wizard_ids)} wizard tables carry a vpsdbId")
+
+    index = fetch_index()
+    jobs = []
+    fallbacks = 0
+    for vps_id in wizard_ids:
+        entry = index.get(vps_id) or {}
+        for kind in KINDS:
+            url, tier = pick_source(entry, kind)
+            if url:
+                jobs.append((vps_id, kind, url))
+                if tier == "4k":
+                    fallbacks += 1
+                    print(f"[INFO] {vps_id}/{kind}: no 1k, using 4k instead")
+    print(f"{len(jobs)} images to mirror (up to {len(KINDS)} per table, {fallbacks} via 4k fallback)")
+
+    out_dir = Path(args.out)
+    media_dir = out_dir / "media"
+    base_url = args.base_url if args.base_url.endswith("/") else args.base_url + "/"
+
+    trimmed = {}
+    ok = 0
+    with ThreadPoolExecutor(max_workers=args.workers) as pool:
+        futures = [pool.submit(convert_one, vid, kind, url, media_dir) for vid, kind, url in jobs]
+        for fut in as_completed(futures):
+            vps_id, kind, success = fut.result()
+            if success:
+                trimmed.setdefault(vps_id, {}).setdefault("1k", {})[kind] = f"{base_url}{vps_id}/{kind}.webp"
+                ok += 1
+
+    out_dir.mkdir(parents=True, exist_ok=True)
+    with open(out_dir / "vpinmdb.json", "w") as f:
+        json.dump(trimmed, f, indent=2, sort_keys=True)
+
+    print(f"Mirrored {ok}/{len(jobs)} images for {len(trimmed)} tables -> {out_dir / 'vpinmdb.json'}")
+    if jobs and ok == 0:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/scripts/requirements-catalog-publish.txt
+++ b/.github/workflows/scripts/requirements-catalog-publish.txt
@@ -1,0 +1,6 @@
+# Deps for the publish-catalog-data.yml workflow (generate-thumbnails.py +
+# generate-vpinmdb-mirror.py). Kept separate from requirements.txt (the main
+# release pipeline's deps) so this workflow doesn't pull in pygithub/GitPython/
+# etc. it never uses.
+Pillow==11.0.0
+requests==2.32.5


### PR DESCRIPTION
## Summary

tm-installer's public Wizard Catalog page needs `manifest.json`, box art, and
vpinmediadb backglass/playfield/FSS art readable **directly from the
browser**. GitHub release assets send no `Access-Control-Allow-Origin` header
at all — verified: the redirect chain from both the release download URL and
`api.github.com`'s asset-download endpoint terminates at
`release-assets.githubusercontent.com`, which sends no CORS headers, so a
browser `fetch()` of a release asset is silently blocked even though `curl` or
a server-side fetch works fine. `raw.githubusercontent.com` does send
`Access-Control-Allow-Origin: *`.

- Adds a **standalone** `publish-catalog-data.yml` workflow — chained via
  `workflow_run` after "Create External Folder Releases and Manifest"
  finishes (so it can't race the asset upload), and independently
  `workflow_dispatch`-able for a specific release tag or the latest, without
  re-running the whole zip/manifest build.
- Re-encodes each table's `launcher.png` box art as full-size WebP (q90, no
  resize — measured ~1.08 MB PNG → ~145 KB, small enough that no separate
  thumbnail variant is needed). **Never touches the device-installed release
  zip** (`generate-release.py` is unchanged) — the device still gets PNG.
- Mirrors vpinmediadb's `1k` bg/table/fss art for wizard tables only (not all
  ~1156 upstream entries), re-encoded as 960x540 WebP (q90, ~140 KB measured
  average vs ~3.1 MB PNG source), falling back to vpinmediadb's `4k` tier when
  `1k` is missing rather than dropping that image. Output is a
  vpinmediadb-**compatible** index — same `{id: {"1k": {bg, table, fss}}}`
  shape, just far fewer entries and WebP.
- Publishes everything as a **single fresh orphan commit**, force-pushed to a
  `manifest` branch that exists only for this — no history ever accumulates
  there, since nothing consumes it incrementally.

## Test plan

Manually dispatched against `v2.0.15` on a private fork (2 runs — first
caught a real bug, second succeeded cleanly):

- [x] 790/790 box-art images generated
- [x] 745/745 vpinmediadb images mirrored for 281 tables (5 recovered via the
      4k fallback)
- [x] `manifest` branch confirmed as a single commit, 0 parents
- [x] All published files return 200 with `Access-Control-Allow-Origin: *`
      from `raw.githubusercontent.com`
- [x] tm-installer's catalog page verified end-to-end in a headless browser
      against the mirrored data (hero slideshow, grid/list box art, detail
      drawer all rendering correctly, no console errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)